### PR TITLE
Make TransactionManager Singleton for in-memory and local bindings.

### DIFF
--- a/tephra-core/src/main/java/org/apache/tephra/runtime/TransactionInMemoryModule.java
+++ b/tephra-core/src/main/java/org/apache/tephra/runtime/TransactionInMemoryModule.java
@@ -20,7 +20,6 @@ package org.apache.tephra.runtime;
 
 import com.google.inject.AbstractModule;
 import com.google.inject.Scopes;
-import com.google.inject.Singleton;
 import com.google.inject.assistedinject.FactoryModuleBuilder;
 import org.apache.tephra.DefaultTransactionExecutor;
 import org.apache.tephra.TransactionExecutor;
@@ -39,16 +38,12 @@ import org.apache.tephra.snapshot.SnapshotCodecProvider;
  * test classes, as the transaction state cannot be recovered in the case of a failure.
  */
 public class TransactionInMemoryModule extends AbstractModule {
-  public TransactionInMemoryModule() {
-  }
 
   @Override
   protected void configure() {
-    // some of these classes need to be non-singleton in order to create a new instance during leader() in
-    // TransactionService
     bind(SnapshotCodecProvider.class).in(Scopes.SINGLETON);
-    bind(TransactionStateStorage.class).to(NoOpTransactionStateStorage.class);
-    bind(TransactionManager.class);
+    bind(TransactionStateStorage.class).to(NoOpTransactionStateStorage.class).in(Scopes.SINGLETON);
+    bind(TransactionManager.class).in(Scopes.SINGLETON);
     bind(TransactionSystemClient.class).to(InMemoryTxSystemClient.class).in(Scopes.SINGLETON);
     // no metrics output for in-memory
     bind(MetricsCollector.class).to(TxMetricsCollector.class);

--- a/tephra-core/src/main/java/org/apache/tephra/runtime/TransactionLocalModule.java
+++ b/tephra-core/src/main/java/org/apache/tephra/runtime/TransactionLocalModule.java
@@ -19,6 +19,7 @@
 package org.apache.tephra.runtime;
 
 import com.google.inject.AbstractModule;
+import com.google.inject.Scopes;
 import com.google.inject.Singleton;
 import com.google.inject.assistedinject.FactoryModuleBuilder;
 import com.google.inject.name.Names;
@@ -41,14 +42,12 @@ final class TransactionLocalModule extends AbstractModule {
 
   @Override
   protected void configure() {
-    // some of these classes need to be non-singleton in order to create a new instance during leader() in
-    // TransactionService
     bind(SnapshotCodecProvider.class).in(Singleton.class);
     bind(TransactionStateStorage.class).annotatedWith(Names.named("persist"))
-      .to(LocalFileTransactionStateStorage.class);
-    bind(TransactionStateStorage.class).toProvider(TransactionStateStorageProvider.class);
+      .to(LocalFileTransactionStateStorage.class).in(Scopes.SINGLETON);
+    bind(TransactionStateStorage.class).toProvider(TransactionStateStorageProvider.class).in(Scopes.SINGLETON);
 
-    bind(TransactionManager.class);
+    bind(TransactionManager.class).in(Scopes.SINGLETON);
     bind(TransactionSystemClient.class).to(InMemoryTxSystemClient.class).in(Singleton.class);
     bind(MetricsCollector.class).to(DefaultMetricsCollector.class);
 


### PR DESCRIPTION
We don't have leader/follower logic happen in in-memory and local mode, so don't need TransactionManager to be singleton there.

This allows test cases that use the TransactionManager directly in the client to share the same instance.