### PR TITLE
Add methods to help testing Transaction Manager

### DIFF
--- a/tephra-core/src/main/java/org/apache/tephra/TransactionManager.java
+++ b/tephra-core/src/main/java/org/apache/tephra/TransactionManager.java
@@ -18,6 +18,7 @@
 
 package org.apache.tephra;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Stopwatch;
@@ -1263,6 +1264,12 @@ public class TransactionManager extends AbstractService {
                ", in progress = " + inProgress.size() +
                ", committing = " + committingChangeSets.size() +
                ", committed = " + committedChangeSets.size());
+  }
+
+  @SuppressWarnings("unused")
+  @VisibleForTesting
+  public TransactionStateStorage getTransactionStateStorage() {
+    return persistor;
   }
 
   private abstract static class DaemonThreadExecutor extends Thread {

--- a/tephra-core/src/main/java/org/apache/tephra/distributed/TransactionService.java
+++ b/tephra-core/src/main/java/org/apache/tephra/distributed/TransactionService.java
@@ -42,6 +42,7 @@ import java.net.UnknownHostException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import javax.annotation.Nullable;
 
 /**
  *
@@ -152,5 +153,12 @@ public final class TransactionService extends InMemoryTransactionService {
         LOG.error("Exception when cancelling leader election.", e);
       }
     }
+  }
+
+  @SuppressWarnings({"WeakerAccess", "unused"})
+  @VisibleForTesting
+  @Nullable
+  public TransactionManager getTransactionManager() {
+    return txManager;
   }
 }


### PR DESCRIPTION
PR https://github.com/apache/incubator-tephra/pull/2 made Transaction Manager and other classes non-singleton. This PR adds methods to fetch Transaction Manager and Transaction State Storage used by Transaction Service.