### PR TITLE
[TEPHRA-194] Make startShort() throw IllegalArgumentException …

### DIFF
--- a/tephra-core/src/main/java/org/apache/tephra/TransactionSystemClient.java
+++ b/tephra-core/src/main/java/org/apache/tephra/TransactionSystemClient.java
@@ -39,6 +39,7 @@ public interface TransactionSystemClient {
    * Starts new short transaction.
    * @param timeout the timeout for the transaction
    * @return instance of {@link Transaction}
+   * @throws IllegalArgumentException if the provided timeout is negative or exceeds the configured maximum
    */
   Transaction startShort(int timeout);
 

--- a/tephra-core/src/main/java/org/apache/tephra/distributed/RetryNTimes.java
+++ b/tephra-core/src/main/java/org/apache/tephra/distributed/RetryNTimes.java
@@ -28,18 +28,18 @@ import org.apache.tephra.TxConstants;
  */
 public class RetryNTimes extends RetryStrategy {
 
-  int attempts = 0;
-  int limit;
+  private int attempts = 0;
+  private int limit;
 
   /**
    * @param maxAttempts the number of attempts after which to stop
    */
-  protected RetryNTimes(int maxAttempts) {
+  private RetryNTimes(int maxAttempts) {
     limit = maxAttempts;
   }
 
   @Override
-  boolean failOnce() {
+  public boolean failOnce() {
     ++attempts;
     return attempts < limit;
   }

--- a/tephra-core/src/main/java/org/apache/tephra/distributed/RetryWithBackoff.java
+++ b/tephra-core/src/main/java/org/apache/tephra/distributed/RetryWithBackoff.java
@@ -33,33 +33,31 @@ public class RetryWithBackoff extends RetryStrategy {
   private static final Logger LOG =
       LoggerFactory.getLogger(RetryWithBackoff.class);
 
-  int initialSleep; // initial sleep time
-  int backoffFactor; // factor by which to increase sleep for each retry
-  int maxSleep; // max sleep time. stop retrying when we exceed this
-  int sleep; // current sleep time
+  private int backoffFactor; // factor by which to increase sleep for each retry
+  private int maxSleep; // max sleep time. stop retrying when we exceed this
+  private int sleep; // current sleep time
 
   /**
-   * @param initial the initial sleep time (before first retry)
+   * @param initialSleep the initial sleep time (before first retry)
    * @param backoff the backoff factor by which sleep time is multiplied
    *                after each retry
    * @param limit the max sleep time. if sleep time reaches this limit, we
    *              stop retrying
    */
-  protected RetryWithBackoff(int initial, int backoff, int limit) {
-    initialSleep = initial;
+  private RetryWithBackoff(int initialSleep, int backoff, int limit) {
     backoffFactor = backoff;
     maxSleep = limit;
     sleep = initialSleep;
   }
 
   @Override
-  boolean failOnce() {
+  public boolean failOnce() {
     return sleep < maxSleep;
   }
 
   @Override
-  void beforeRetry() {
-    LOG.info("Sleeping " + sleep + " ms before retry.");
+  public void beforeRetry() {
+    LOG.debug("Sleeping " + sleep + " ms before retry.");
     long current = System.currentTimeMillis();
     long end = current + sleep;
     while (current < end) {

--- a/tephra-core/src/main/java/org/apache/tephra/distributed/TransactionServiceThriftHandler.java
+++ b/tephra-core/src/main/java/org/apache/tephra/distributed/TransactionServiceThriftHandler.java
@@ -24,6 +24,7 @@ import org.apache.tephra.TransactionManager;
 import org.apache.tephra.TransactionNotInProgressException;
 import org.apache.tephra.TxConstants;
 import org.apache.tephra.distributed.thrift.TBoolean;
+import org.apache.tephra.distributed.thrift.TGenericException;
 import org.apache.tephra.distributed.thrift.TInvalidTruncateTimeException;
 import org.apache.tephra.distributed.thrift.TTransaction;
 import org.apache.tephra.distributed.thrift.TTransactionCouldNotTakeSnapshotException;
@@ -76,6 +77,14 @@ public class TransactionServiceThriftHandler implements TTransactionServer.Iface
     return TransactionConverterUtils.wrap(txManager.startShort(timeout));
   }
 
+  @Override
+  public TTransaction startShortWithTimeout(int timeout) throws TException {
+    try {
+      return TransactionConverterUtils.wrap(txManager.startShort(timeout));
+    } catch (IllegalArgumentException e) {
+      throw new TGenericException(e.getMessage(), e.getClass().getName());
+    }
+  }
 
   @Override
   public TBoolean canCommitTx(TTransaction tx, Set<ByteBuffer> changes) throws TException {

--- a/tephra-core/src/main/java/org/apache/tephra/distributed/thrift/TBoolean.java
+++ b/tephra-core/src/main/java/org/apache/tephra/distributed/thrift/TBoolean.java
@@ -24,19 +24,29 @@
  */
 package org.apache.tephra.distributed.thrift;
 
-import org.apache.thrift.EncodingUtils;
-import org.apache.thrift.protocol.TTupleProtocol;
 import org.apache.thrift.scheme.IScheme;
 import org.apache.thrift.scheme.SchemeFactory;
 import org.apache.thrift.scheme.StandardScheme;
-import org.apache.thrift.scheme.TupleScheme;
 
-import java.util.BitSet;
-import java.util.Collections;
-import java.util.EnumMap;
-import java.util.EnumSet;
-import java.util.HashMap;
+import org.apache.thrift.scheme.TupleScheme;
+import org.apache.thrift.protocol.TTupleProtocol;
+import org.apache.thrift.protocol.TProtocolException;
+import org.apache.thrift.EncodingUtils;
+import org.apache.thrift.TException;
+import java.util.List;
+import java.util.ArrayList;
 import java.util.Map;
+import java.util.HashMap;
+import java.util.EnumMap;
+import java.util.Set;
+import java.util.HashSet;
+import java.util.EnumSet;
+import java.util.Collections;
+import java.util.BitSet;
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class TBoolean implements org.apache.thrift.TBase<TBoolean, TBoolean._Fields>, java.io.Serializable, Cloneable {
   private static final org.apache.thrift.protocol.TStruct STRUCT_DESC = new org.apache.thrift.protocol.TStruct("TBoolean");

--- a/tephra-core/src/main/java/org/apache/tephra/distributed/thrift/TGenericException.java
+++ b/tephra-core/src/main/java/org/apache/tephra/distributed/thrift/TGenericException.java
@@ -48,22 +48,25 @@ import java.util.Arrays;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class TTransactionNotInProgressException extends TException implements org.apache.thrift.TBase<TTransactionNotInProgressException, TTransactionNotInProgressException._Fields>, java.io.Serializable, Cloneable {
-  private static final org.apache.thrift.protocol.TStruct STRUCT_DESC = new org.apache.thrift.protocol.TStruct("TTransactionNotInProgressException");
+public class TGenericException extends TException implements org.apache.thrift.TBase<TGenericException, TGenericException._Fields>, java.io.Serializable, Cloneable {
+  private static final org.apache.thrift.protocol.TStruct STRUCT_DESC = new org.apache.thrift.protocol.TStruct("TGenericException");
 
   private static final org.apache.thrift.protocol.TField MESSAGE_FIELD_DESC = new org.apache.thrift.protocol.TField("message", org.apache.thrift.protocol.TType.STRING, (short)1);
+  private static final org.apache.thrift.protocol.TField ORIGINAL_EXCEPTION_CLASS_FIELD_DESC = new org.apache.thrift.protocol.TField("originalExceptionClass", org.apache.thrift.protocol.TType.STRING, (short)2);
 
   private static final Map<Class<? extends IScheme>, SchemeFactory> schemes = new HashMap<Class<? extends IScheme>, SchemeFactory>();
   static {
-    schemes.put(StandardScheme.class, new TTransactionNotInProgressExceptionStandardSchemeFactory());
-    schemes.put(TupleScheme.class, new TTransactionNotInProgressExceptionTupleSchemeFactory());
+    schemes.put(StandardScheme.class, new TGenericExceptionStandardSchemeFactory());
+    schemes.put(TupleScheme.class, new TGenericExceptionTupleSchemeFactory());
   }
 
   public String message; // required
+  public String originalExceptionClass; // required
 
   /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
   public enum _Fields implements org.apache.thrift.TFieldIdEnum {
-    MESSAGE((short)1, "message");
+    MESSAGE((short)1, "message"),
+    ORIGINAL_EXCEPTION_CLASS((short)2, "originalExceptionClass");
 
     private static final Map<String, _Fields> byName = new HashMap<String, _Fields>();
 
@@ -80,6 +83,8 @@ public class TTransactionNotInProgressException extends TException implements or
       switch(fieldId) {
         case 1: // MESSAGE
           return MESSAGE;
+        case 2: // ORIGINAL_EXCEPTION_CLASS
+          return ORIGINAL_EXCEPTION_CLASS;
         default:
           return null;
       }
@@ -125,43 +130,51 @@ public class TTransactionNotInProgressException extends TException implements or
     Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> tmpMap = new EnumMap<_Fields, org.apache.thrift.meta_data.FieldMetaData>(_Fields.class);
     tmpMap.put(_Fields.MESSAGE, new org.apache.thrift.meta_data.FieldMetaData("message", org.apache.thrift.TFieldRequirementType.DEFAULT, 
         new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.STRING)));
+    tmpMap.put(_Fields.ORIGINAL_EXCEPTION_CLASS, new org.apache.thrift.meta_data.FieldMetaData("originalExceptionClass", org.apache.thrift.TFieldRequirementType.DEFAULT, 
+        new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.STRING)));
     metaDataMap = Collections.unmodifiableMap(tmpMap);
-    org.apache.thrift.meta_data.FieldMetaData.addStructMetaDataMap(TTransactionNotInProgressException.class, metaDataMap);
+    org.apache.thrift.meta_data.FieldMetaData.addStructMetaDataMap(TGenericException.class, metaDataMap);
   }
 
-  public TTransactionNotInProgressException() {
+  public TGenericException() {
   }
 
-  public TTransactionNotInProgressException(
-    String message)
+  public TGenericException(
+    String message,
+    String originalExceptionClass)
   {
     this();
     this.message = message;
+    this.originalExceptionClass = originalExceptionClass;
   }
 
   /**
    * Performs a deep copy on <i>other</i>.
    */
-  public TTransactionNotInProgressException(TTransactionNotInProgressException other) {
+  public TGenericException(TGenericException other) {
     if (other.isSetMessage()) {
       this.message = other.message;
     }
+    if (other.isSetOriginalExceptionClass()) {
+      this.originalExceptionClass = other.originalExceptionClass;
+    }
   }
 
-  public TTransactionNotInProgressException deepCopy() {
-    return new TTransactionNotInProgressException(this);
+  public TGenericException deepCopy() {
+    return new TGenericException(this);
   }
 
   @Override
   public void clear() {
     this.message = null;
+    this.originalExceptionClass = null;
   }
 
   public String getMessage() {
     return this.message;
   }
 
-  public TTransactionNotInProgressException setMessage(String message) {
+  public TGenericException setMessage(String message) {
     this.message = message;
     return this;
   }
@@ -181,6 +194,30 @@ public class TTransactionNotInProgressException extends TException implements or
     }
   }
 
+  public String getOriginalExceptionClass() {
+    return this.originalExceptionClass;
+  }
+
+  public TGenericException setOriginalExceptionClass(String originalExceptionClass) {
+    this.originalExceptionClass = originalExceptionClass;
+    return this;
+  }
+
+  public void unsetOriginalExceptionClass() {
+    this.originalExceptionClass = null;
+  }
+
+  /** Returns true if field originalExceptionClass is set (has been assigned a value) and false otherwise */
+  public boolean isSetOriginalExceptionClass() {
+    return this.originalExceptionClass != null;
+  }
+
+  public void setOriginalExceptionClassIsSet(boolean value) {
+    if (!value) {
+      this.originalExceptionClass = null;
+    }
+  }
+
   public void setFieldValue(_Fields field, Object value) {
     switch (field) {
     case MESSAGE:
@@ -191,6 +228,14 @@ public class TTransactionNotInProgressException extends TException implements or
       }
       break;
 
+    case ORIGINAL_EXCEPTION_CLASS:
+      if (value == null) {
+        unsetOriginalExceptionClass();
+      } else {
+        setOriginalExceptionClass((String)value);
+      }
+      break;
+
     }
   }
 
@@ -198,6 +243,9 @@ public class TTransactionNotInProgressException extends TException implements or
     switch (field) {
     case MESSAGE:
       return getMessage();
+
+    case ORIGINAL_EXCEPTION_CLASS:
+      return getOriginalExceptionClass();
 
     }
     throw new IllegalStateException();
@@ -212,6 +260,8 @@ public class TTransactionNotInProgressException extends TException implements or
     switch (field) {
     case MESSAGE:
       return isSetMessage();
+    case ORIGINAL_EXCEPTION_CLASS:
+      return isSetOriginalExceptionClass();
     }
     throw new IllegalStateException();
   }
@@ -220,12 +270,12 @@ public class TTransactionNotInProgressException extends TException implements or
   public boolean equals(Object that) {
     if (that == null)
       return false;
-    if (that instanceof TTransactionNotInProgressException)
-      return this.equals((TTransactionNotInProgressException)that);
+    if (that instanceof TGenericException)
+      return this.equals((TGenericException)that);
     return false;
   }
 
-  public boolean equals(TTransactionNotInProgressException that) {
+  public boolean equals(TGenericException that) {
     if (that == null)
       return false;
 
@@ -238,6 +288,15 @@ public class TTransactionNotInProgressException extends TException implements or
         return false;
     }
 
+    boolean this_present_originalExceptionClass = true && this.isSetOriginalExceptionClass();
+    boolean that_present_originalExceptionClass = true && that.isSetOriginalExceptionClass();
+    if (this_present_originalExceptionClass || that_present_originalExceptionClass) {
+      if (!(this_present_originalExceptionClass && that_present_originalExceptionClass))
+        return false;
+      if (!this.originalExceptionClass.equals(that.originalExceptionClass))
+        return false;
+    }
+
     return true;
   }
 
@@ -246,13 +305,13 @@ public class TTransactionNotInProgressException extends TException implements or
     return 0;
   }
 
-  public int compareTo(TTransactionNotInProgressException other) {
+  public int compareTo(TGenericException other) {
     if (!getClass().equals(other.getClass())) {
       return getClass().getName().compareTo(other.getClass().getName());
     }
 
     int lastComparison = 0;
-    TTransactionNotInProgressException typedOther = (TTransactionNotInProgressException)other;
+    TGenericException typedOther = (TGenericException)other;
 
     lastComparison = Boolean.valueOf(isSetMessage()).compareTo(typedOther.isSetMessage());
     if (lastComparison != 0) {
@@ -260,6 +319,16 @@ public class TTransactionNotInProgressException extends TException implements or
     }
     if (isSetMessage()) {
       lastComparison = org.apache.thrift.TBaseHelper.compareTo(this.message, typedOther.message);
+      if (lastComparison != 0) {
+        return lastComparison;
+      }
+    }
+    lastComparison = Boolean.valueOf(isSetOriginalExceptionClass()).compareTo(typedOther.isSetOriginalExceptionClass());
+    if (lastComparison != 0) {
+      return lastComparison;
+    }
+    if (isSetOriginalExceptionClass()) {
+      lastComparison = org.apache.thrift.TBaseHelper.compareTo(this.originalExceptionClass, typedOther.originalExceptionClass);
       if (lastComparison != 0) {
         return lastComparison;
       }
@@ -281,7 +350,7 @@ public class TTransactionNotInProgressException extends TException implements or
 
   @Override
   public String toString() {
-    StringBuilder sb = new StringBuilder("TTransactionNotInProgressException(");
+    StringBuilder sb = new StringBuilder("TGenericException(");
     boolean first = true;
 
     sb.append("message:");
@@ -289,6 +358,14 @@ public class TTransactionNotInProgressException extends TException implements or
       sb.append("null");
     } else {
       sb.append(this.message);
+    }
+    first = false;
+    if (!first) sb.append(", ");
+    sb.append("originalExceptionClass:");
+    if (this.originalExceptionClass == null) {
+      sb.append("null");
+    } else {
+      sb.append(this.originalExceptionClass);
     }
     first = false;
     sb.append(")");
@@ -316,15 +393,15 @@ public class TTransactionNotInProgressException extends TException implements or
     }
   }
 
-  private static class TTransactionNotInProgressExceptionStandardSchemeFactory implements SchemeFactory {
-    public TTransactionNotInProgressExceptionStandardScheme getScheme() {
-      return new TTransactionNotInProgressExceptionStandardScheme();
+  private static class TGenericExceptionStandardSchemeFactory implements SchemeFactory {
+    public TGenericExceptionStandardScheme getScheme() {
+      return new TGenericExceptionStandardScheme();
     }
   }
 
-  private static class TTransactionNotInProgressExceptionStandardScheme extends StandardScheme<TTransactionNotInProgressException> {
+  private static class TGenericExceptionStandardScheme extends StandardScheme<TGenericException> {
 
-    public void read(org.apache.thrift.protocol.TProtocol iprot, TTransactionNotInProgressException struct) throws org.apache.thrift.TException {
+    public void read(org.apache.thrift.protocol.TProtocol iprot, TGenericException struct) throws org.apache.thrift.TException {
       org.apache.thrift.protocol.TField schemeField;
       iprot.readStructBegin();
       while (true)
@@ -342,6 +419,14 @@ public class TTransactionNotInProgressException extends TException implements or
               org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
             }
             break;
+          case 2: // ORIGINAL_EXCEPTION_CLASS
+            if (schemeField.type == org.apache.thrift.protocol.TType.STRING) {
+              struct.originalExceptionClass = iprot.readString();
+              struct.setOriginalExceptionClassIsSet(true);
+            } else { 
+              org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
+            }
+            break;
           default:
             org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
         }
@@ -353,7 +438,7 @@ public class TTransactionNotInProgressException extends TException implements or
       struct.validate();
     }
 
-    public void write(org.apache.thrift.protocol.TProtocol oprot, TTransactionNotInProgressException struct) throws org.apache.thrift.TException {
+    public void write(org.apache.thrift.protocol.TProtocol oprot, TGenericException struct) throws org.apache.thrift.TException {
       struct.validate();
 
       oprot.writeStructBegin(STRUCT_DESC);
@@ -362,40 +447,55 @@ public class TTransactionNotInProgressException extends TException implements or
         oprot.writeString(struct.message);
         oprot.writeFieldEnd();
       }
+      if (struct.originalExceptionClass != null) {
+        oprot.writeFieldBegin(ORIGINAL_EXCEPTION_CLASS_FIELD_DESC);
+        oprot.writeString(struct.originalExceptionClass);
+        oprot.writeFieldEnd();
+      }
       oprot.writeFieldStop();
       oprot.writeStructEnd();
     }
 
   }
 
-  private static class TTransactionNotInProgressExceptionTupleSchemeFactory implements SchemeFactory {
-    public TTransactionNotInProgressExceptionTupleScheme getScheme() {
-      return new TTransactionNotInProgressExceptionTupleScheme();
+  private static class TGenericExceptionTupleSchemeFactory implements SchemeFactory {
+    public TGenericExceptionTupleScheme getScheme() {
+      return new TGenericExceptionTupleScheme();
     }
   }
 
-  private static class TTransactionNotInProgressExceptionTupleScheme extends TupleScheme<TTransactionNotInProgressException> {
+  private static class TGenericExceptionTupleScheme extends TupleScheme<TGenericException> {
 
     @Override
-    public void write(org.apache.thrift.protocol.TProtocol prot, TTransactionNotInProgressException struct) throws org.apache.thrift.TException {
+    public void write(org.apache.thrift.protocol.TProtocol prot, TGenericException struct) throws org.apache.thrift.TException {
       TTupleProtocol oprot = (TTupleProtocol) prot;
       BitSet optionals = new BitSet();
       if (struct.isSetMessage()) {
         optionals.set(0);
       }
-      oprot.writeBitSet(optionals, 1);
+      if (struct.isSetOriginalExceptionClass()) {
+        optionals.set(1);
+      }
+      oprot.writeBitSet(optionals, 2);
       if (struct.isSetMessage()) {
         oprot.writeString(struct.message);
+      }
+      if (struct.isSetOriginalExceptionClass()) {
+        oprot.writeString(struct.originalExceptionClass);
       }
     }
 
     @Override
-    public void read(org.apache.thrift.protocol.TProtocol prot, TTransactionNotInProgressException struct) throws org.apache.thrift.TException {
+    public void read(org.apache.thrift.protocol.TProtocol prot, TGenericException struct) throws org.apache.thrift.TException {
       TTupleProtocol iprot = (TTupleProtocol) prot;
-      BitSet incoming = iprot.readBitSet(1);
+      BitSet incoming = iprot.readBitSet(2);
       if (incoming.get(0)) {
         struct.message = iprot.readString();
         struct.setMessageIsSet(true);
+      }
+      if (incoming.get(1)) {
+        struct.originalExceptionClass = iprot.readString();
+        struct.setOriginalExceptionClassIsSet(true);
       }
     }
   }

--- a/tephra-core/src/main/java/org/apache/tephra/distributed/thrift/TInvalidTruncateTimeException.java
+++ b/tephra-core/src/main/java/org/apache/tephra/distributed/thrift/TInvalidTruncateTimeException.java
@@ -24,19 +24,29 @@
  */
 package org.apache.tephra.distributed.thrift;
 
-import org.apache.thrift.TException;
-import org.apache.thrift.protocol.TTupleProtocol;
 import org.apache.thrift.scheme.IScheme;
 import org.apache.thrift.scheme.SchemeFactory;
 import org.apache.thrift.scheme.StandardScheme;
-import org.apache.thrift.scheme.TupleScheme;
 
-import java.util.BitSet;
-import java.util.Collections;
-import java.util.EnumMap;
-import java.util.EnumSet;
-import java.util.HashMap;
+import org.apache.thrift.scheme.TupleScheme;
+import org.apache.thrift.protocol.TTupleProtocol;
+import org.apache.thrift.protocol.TProtocolException;
+import org.apache.thrift.EncodingUtils;
+import org.apache.thrift.TException;
+import java.util.List;
+import java.util.ArrayList;
 import java.util.Map;
+import java.util.HashMap;
+import java.util.EnumMap;
+import java.util.Set;
+import java.util.HashSet;
+import java.util.EnumSet;
+import java.util.Collections;
+import java.util.BitSet;
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class TInvalidTruncateTimeException extends TException implements org.apache.thrift.TBase<TInvalidTruncateTimeException, TInvalidTruncateTimeException._Fields>, java.io.Serializable, Cloneable {
   private static final org.apache.thrift.protocol.TStruct STRUCT_DESC = new org.apache.thrift.protocol.TStruct("TInvalidTruncateTimeException");

--- a/tephra-core/src/main/java/org/apache/tephra/distributed/thrift/TTransaction.java
+++ b/tephra-core/src/main/java/org/apache/tephra/distributed/thrift/TTransaction.java
@@ -24,21 +24,29 @@
  */
 package org.apache.tephra.distributed.thrift;
 
-import org.apache.thrift.EncodingUtils;
-import org.apache.thrift.protocol.TTupleProtocol;
 import org.apache.thrift.scheme.IScheme;
 import org.apache.thrift.scheme.SchemeFactory;
 import org.apache.thrift.scheme.StandardScheme;
-import org.apache.thrift.scheme.TupleScheme;
 
-import java.util.ArrayList;
-import java.util.BitSet;
-import java.util.Collections;
-import java.util.EnumMap;
-import java.util.EnumSet;
-import java.util.HashMap;
+import org.apache.thrift.scheme.TupleScheme;
+import org.apache.thrift.protocol.TTupleProtocol;
+import org.apache.thrift.protocol.TProtocolException;
+import org.apache.thrift.EncodingUtils;
+import org.apache.thrift.TException;
 import java.util.List;
+import java.util.ArrayList;
 import java.util.Map;
+import java.util.HashMap;
+import java.util.EnumMap;
+import java.util.Set;
+import java.util.HashSet;
+import java.util.EnumSet;
+import java.util.Collections;
+import java.util.BitSet;
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class TTransaction implements org.apache.thrift.TBase<TTransaction, TTransaction._Fields>, java.io.Serializable, Cloneable {
   private static final org.apache.thrift.protocol.TStruct STRUCT_DESC = new org.apache.thrift.protocol.TStruct("TTransaction");

--- a/tephra-core/src/main/java/org/apache/tephra/distributed/thrift/TTransactionCouldNotTakeSnapshotException.java
+++ b/tephra-core/src/main/java/org/apache/tephra/distributed/thrift/TTransactionCouldNotTakeSnapshotException.java
@@ -24,19 +24,29 @@
  */
 package org.apache.tephra.distributed.thrift;
 
-import org.apache.thrift.TException;
-import org.apache.thrift.protocol.TTupleProtocol;
 import org.apache.thrift.scheme.IScheme;
 import org.apache.thrift.scheme.SchemeFactory;
 import org.apache.thrift.scheme.StandardScheme;
-import org.apache.thrift.scheme.TupleScheme;
 
-import java.util.BitSet;
-import java.util.Collections;
-import java.util.EnumMap;
-import java.util.EnumSet;
-import java.util.HashMap;
+import org.apache.thrift.scheme.TupleScheme;
+import org.apache.thrift.protocol.TTupleProtocol;
+import org.apache.thrift.protocol.TProtocolException;
+import org.apache.thrift.EncodingUtils;
+import org.apache.thrift.TException;
+import java.util.List;
+import java.util.ArrayList;
 import java.util.Map;
+import java.util.HashMap;
+import java.util.EnumMap;
+import java.util.Set;
+import java.util.HashSet;
+import java.util.EnumSet;
+import java.util.Collections;
+import java.util.BitSet;
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class TTransactionCouldNotTakeSnapshotException extends TException implements org.apache.thrift.TBase<TTransactionCouldNotTakeSnapshotException, TTransactionCouldNotTakeSnapshotException._Fields>, java.io.Serializable, Cloneable {
   private static final org.apache.thrift.protocol.TStruct STRUCT_DESC = new org.apache.thrift.protocol.TStruct("TTransactionCouldNotTakeSnapshotException");

--- a/tephra-core/src/main/java/org/apache/tephra/distributed/thrift/TTransactionServer.java
+++ b/tephra-core/src/main/java/org/apache/tephra/distributed/thrift/TTransactionServer.java
@@ -24,24 +24,29 @@
  */
 package org.apache.tephra.distributed.thrift;
 
-import org.apache.thrift.EncodingUtils;
-import org.apache.thrift.protocol.TTupleProtocol;
 import org.apache.thrift.scheme.IScheme;
 import org.apache.thrift.scheme.SchemeFactory;
 import org.apache.thrift.scheme.StandardScheme;
+
 import org.apache.thrift.scheme.TupleScheme;
+import org.apache.thrift.protocol.TTupleProtocol;
+import org.apache.thrift.protocol.TProtocolException;
+import org.apache.thrift.EncodingUtils;
+import org.apache.thrift.TException;
+import java.util.List;
+import java.util.ArrayList;
+import java.util.Map;
+import java.util.HashMap;
+import java.util.EnumMap;
+import java.util.Set;
+import java.util.HashSet;
+import java.util.EnumSet;
+import java.util.Collections;
+import java.util.BitSet;
+import java.nio.ByteBuffer;
+import java.util.Arrays;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.nio.ByteBuffer;
-import java.util.BitSet;
-import java.util.Collections;
-import java.util.EnumMap;
-import java.util.EnumSet;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
 
 public class TTransactionServer {
 
@@ -52,6 +57,8 @@ public class TTransactionServer {
     public TTransaction startShort() throws org.apache.thrift.TException;
 
     public TTransaction startShortTimeout(int timeout) throws org.apache.thrift.TException;
+
+    public TTransaction startShortWithTimeout(int timeout) throws TGenericException, org.apache.thrift.TException;
 
     public TBoolean canCommitTx(TTransaction tx, Set<ByteBuffer> changes) throws TTransactionNotInProgressException, org.apache.thrift.TException;
 
@@ -84,6 +91,8 @@ public class TTransactionServer {
     public void startShort(org.apache.thrift.async.AsyncMethodCallback<AsyncClient.startShort_call> resultHandler) throws org.apache.thrift.TException;
 
     public void startShortTimeout(int timeout, org.apache.thrift.async.AsyncMethodCallback<AsyncClient.startShortTimeout_call> resultHandler) throws org.apache.thrift.TException;
+
+    public void startShortWithTimeout(int timeout, org.apache.thrift.async.AsyncMethodCallback<AsyncClient.startShortWithTimeout_call> resultHandler) throws org.apache.thrift.TException;
 
     public void canCommitTx(TTransaction tx, Set<ByteBuffer> changes, org.apache.thrift.async.AsyncMethodCallback<AsyncClient.canCommitTx_call> resultHandler) throws org.apache.thrift.TException;
 
@@ -194,6 +203,32 @@ public class TTransactionServer {
         return result.success;
       }
       throw new org.apache.thrift.TApplicationException(org.apache.thrift.TApplicationException.MISSING_RESULT, "startShortTimeout failed: unknown result");
+    }
+
+    public TTransaction startShortWithTimeout(int timeout) throws TGenericException, org.apache.thrift.TException
+    {
+      send_startShortWithTimeout(timeout);
+      return recv_startShortWithTimeout();
+    }
+
+    public void send_startShortWithTimeout(int timeout) throws org.apache.thrift.TException
+    {
+      startShortWithTimeout_args args = new startShortWithTimeout_args();
+      args.setTimeout(timeout);
+      sendBase("startShortWithTimeout", args);
+    }
+
+    public TTransaction recv_startShortWithTimeout() throws TGenericException, org.apache.thrift.TException
+    {
+      startShortWithTimeout_result result = new startShortWithTimeout_result();
+      receiveBase(result, "startShortWithTimeout");
+      if (result.isSetSuccess()) {
+        return result.success;
+      }
+      if (result.e != null) {
+        throw result.e;
+      }
+      throw new org.apache.thrift.TApplicationException(org.apache.thrift.TApplicationException.MISSING_RESULT, "startShortWithTimeout failed: unknown result");
     }
 
     public TBoolean canCommitTx(TTransaction tx, Set<ByteBuffer> changes) throws TTransactionNotInProgressException, org.apache.thrift.TException
@@ -563,6 +598,38 @@ public class TTransactionServer {
       }
     }
 
+    public void startShortWithTimeout(int timeout, org.apache.thrift.async.AsyncMethodCallback<startShortWithTimeout_call> resultHandler) throws org.apache.thrift.TException {
+      checkReady();
+      startShortWithTimeout_call method_call = new startShortWithTimeout_call(timeout, resultHandler, this, ___protocolFactory, ___transport);
+      this.___currentMethod = method_call;
+      ___manager.call(method_call);
+    }
+
+    public static class startShortWithTimeout_call extends org.apache.thrift.async.TAsyncMethodCall {
+      private int timeout;
+      public startShortWithTimeout_call(int timeout, org.apache.thrift.async.AsyncMethodCallback<startShortWithTimeout_call> resultHandler, org.apache.thrift.async.TAsyncClient client, org.apache.thrift.protocol.TProtocolFactory protocolFactory, org.apache.thrift.transport.TNonblockingTransport transport) throws org.apache.thrift.TException {
+        super(client, protocolFactory, transport, resultHandler, false);
+        this.timeout = timeout;
+      }
+
+      public void write_args(org.apache.thrift.protocol.TProtocol prot) throws org.apache.thrift.TException {
+        prot.writeMessageBegin(new org.apache.thrift.protocol.TMessage("startShortWithTimeout", org.apache.thrift.protocol.TMessageType.CALL, 0));
+        startShortWithTimeout_args args = new startShortWithTimeout_args();
+        args.setTimeout(timeout);
+        args.write(prot);
+        prot.writeMessageEnd();
+      }
+
+      public TTransaction getResult() throws TGenericException, org.apache.thrift.TException {
+        if (getState() != org.apache.thrift.async.TAsyncMethodCall.State.RESPONSE_READ) {
+          throw new IllegalStateException("Method call not finished!");
+        }
+        org.apache.thrift.transport.TMemoryInputTransport memoryTransport = new org.apache.thrift.transport.TMemoryInputTransport(getFrameBuffer().array());
+        org.apache.thrift.protocol.TProtocol prot = client.getProtocolFactory().getProtocol(memoryTransport);
+        return (new Client(prot)).recv_startShortWithTimeout();
+      }
+    }
+
     public void canCommitTx(TTransaction tx, Set<ByteBuffer> changes, org.apache.thrift.async.AsyncMethodCallback<canCommitTx_call> resultHandler) throws org.apache.thrift.TException {
       checkReady();
       canCommitTx_call method_call = new canCommitTx_call(tx, changes, resultHandler, this, ___protocolFactory, ___transport);
@@ -922,6 +989,7 @@ public class TTransactionServer {
       processMap.put("startLong", new startLong());
       processMap.put("startShort", new startShort());
       processMap.put("startShortTimeout", new startShortTimeout());
+      processMap.put("startShortWithTimeout", new startShortWithTimeout());
       processMap.put("canCommitTx", new canCommitTx());
       processMap.put("commitTx", new commitTx());
       processMap.put("abortTx", new abortTx());
@@ -992,6 +1060,30 @@ public class TTransactionServer {
       public startShortTimeout_result getResult(I iface, startShortTimeout_args args) throws org.apache.thrift.TException {
         startShortTimeout_result result = new startShortTimeout_result();
         result.success = iface.startShortTimeout(args.timeout);
+        return result;
+      }
+    }
+
+    public static class startShortWithTimeout<I extends Iface> extends org.apache.thrift.ProcessFunction<I, startShortWithTimeout_args> {
+      public startShortWithTimeout() {
+        super("startShortWithTimeout");
+      }
+
+      public startShortWithTimeout_args getEmptyArgsInstance() {
+        return new startShortWithTimeout_args();
+      }
+
+      protected boolean isOneway() {
+        return false;
+      }
+
+      public startShortWithTimeout_result getResult(I iface, startShortWithTimeout_args args) throws org.apache.thrift.TException {
+        startShortWithTimeout_result result = new startShortWithTimeout_result();
+        try {
+          result.success = iface.startShortWithTimeout(args.timeout);
+        } catch (TGenericException e) {
+          result.e = e;
+        }
         return result;
       }
     }
@@ -3155,6 +3247,819 @@ public class TTransactionServer {
           struct.success = new TTransaction();
           struct.success.read(iprot);
           struct.setSuccessIsSet(true);
+        }
+      }
+    }
+
+  }
+
+  public static class startShortWithTimeout_args implements org.apache.thrift.TBase<startShortWithTimeout_args, startShortWithTimeout_args._Fields>, java.io.Serializable, Cloneable   {
+    private static final org.apache.thrift.protocol.TStruct STRUCT_DESC = new org.apache.thrift.protocol.TStruct("startShortWithTimeout_args");
+
+    private static final org.apache.thrift.protocol.TField TIMEOUT_FIELD_DESC = new org.apache.thrift.protocol.TField("timeout", org.apache.thrift.protocol.TType.I32, (short)1);
+
+    private static final Map<Class<? extends IScheme>, SchemeFactory> schemes = new HashMap<Class<? extends IScheme>, SchemeFactory>();
+    static {
+      schemes.put(StandardScheme.class, new startShortWithTimeout_argsStandardSchemeFactory());
+      schemes.put(TupleScheme.class, new startShortWithTimeout_argsTupleSchemeFactory());
+    }
+
+    public int timeout; // required
+
+    /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
+    public enum _Fields implements org.apache.thrift.TFieldIdEnum {
+      TIMEOUT((short)1, "timeout");
+
+      private static final Map<String, _Fields> byName = new HashMap<String, _Fields>();
+
+      static {
+        for (_Fields field : EnumSet.allOf(_Fields.class)) {
+          byName.put(field.getFieldName(), field);
+        }
+      }
+
+      /**
+       * Find the _Fields constant that matches fieldId, or null if its not found.
+       */
+      public static _Fields findByThriftId(int fieldId) {
+        switch(fieldId) {
+          case 1: // TIMEOUT
+            return TIMEOUT;
+          default:
+            return null;
+        }
+      }
+
+      /**
+       * Find the _Fields constant that matches fieldId, throwing an exception
+       * if it is not found.
+       */
+      public static _Fields findByThriftIdOrThrow(int fieldId) {
+        _Fields fields = findByThriftId(fieldId);
+        if (fields == null) throw new IllegalArgumentException("Field " + fieldId + " doesn't exist!");
+        return fields;
+      }
+
+      /**
+       * Find the _Fields constant that matches name, or null if its not found.
+       */
+      public static _Fields findByName(String name) {
+        return byName.get(name);
+      }
+
+      private final short _thriftId;
+      private final String _fieldName;
+
+      _Fields(short thriftId, String fieldName) {
+        _thriftId = thriftId;
+        _fieldName = fieldName;
+      }
+
+      public short getThriftFieldId() {
+        return _thriftId;
+      }
+
+      public String getFieldName() {
+        return _fieldName;
+      }
+    }
+
+    // isset id assignments
+    private static final int __TIMEOUT_ISSET_ID = 0;
+    private byte __isset_bitfield = 0;
+    public static final Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> metaDataMap;
+    static {
+      Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> tmpMap = new EnumMap<_Fields, org.apache.thrift.meta_data.FieldMetaData>(_Fields.class);
+      tmpMap.put(_Fields.TIMEOUT, new org.apache.thrift.meta_data.FieldMetaData("timeout", org.apache.thrift.TFieldRequirementType.DEFAULT, 
+          new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.I32)));
+      metaDataMap = Collections.unmodifiableMap(tmpMap);
+      org.apache.thrift.meta_data.FieldMetaData.addStructMetaDataMap(startShortWithTimeout_args.class, metaDataMap);
+    }
+
+    public startShortWithTimeout_args() {
+    }
+
+    public startShortWithTimeout_args(
+      int timeout)
+    {
+      this();
+      this.timeout = timeout;
+      setTimeoutIsSet(true);
+    }
+
+    /**
+     * Performs a deep copy on <i>other</i>.
+     */
+    public startShortWithTimeout_args(startShortWithTimeout_args other) {
+      __isset_bitfield = other.__isset_bitfield;
+      this.timeout = other.timeout;
+    }
+
+    public startShortWithTimeout_args deepCopy() {
+      return new startShortWithTimeout_args(this);
+    }
+
+    @Override
+    public void clear() {
+      setTimeoutIsSet(false);
+      this.timeout = 0;
+    }
+
+    public int getTimeout() {
+      return this.timeout;
+    }
+
+    public startShortWithTimeout_args setTimeout(int timeout) {
+      this.timeout = timeout;
+      setTimeoutIsSet(true);
+      return this;
+    }
+
+    public void unsetTimeout() {
+      __isset_bitfield = EncodingUtils.clearBit(__isset_bitfield, __TIMEOUT_ISSET_ID);
+    }
+
+    /** Returns true if field timeout is set (has been assigned a value) and false otherwise */
+    public boolean isSetTimeout() {
+      return EncodingUtils.testBit(__isset_bitfield, __TIMEOUT_ISSET_ID);
+    }
+
+    public void setTimeoutIsSet(boolean value) {
+      __isset_bitfield = EncodingUtils.setBit(__isset_bitfield, __TIMEOUT_ISSET_ID, value);
+    }
+
+    public void setFieldValue(_Fields field, Object value) {
+      switch (field) {
+      case TIMEOUT:
+        if (value == null) {
+          unsetTimeout();
+        } else {
+          setTimeout((Integer)value);
+        }
+        break;
+
+      }
+    }
+
+    public Object getFieldValue(_Fields field) {
+      switch (field) {
+      case TIMEOUT:
+        return Integer.valueOf(getTimeout());
+
+      }
+      throw new IllegalStateException();
+    }
+
+    /** Returns true if field corresponding to fieldID is set (has been assigned a value) and false otherwise */
+    public boolean isSet(_Fields field) {
+      if (field == null) {
+        throw new IllegalArgumentException();
+      }
+
+      switch (field) {
+      case TIMEOUT:
+        return isSetTimeout();
+      }
+      throw new IllegalStateException();
+    }
+
+    @Override
+    public boolean equals(Object that) {
+      if (that == null)
+        return false;
+      if (that instanceof startShortWithTimeout_args)
+        return this.equals((startShortWithTimeout_args)that);
+      return false;
+    }
+
+    public boolean equals(startShortWithTimeout_args that) {
+      if (that == null)
+        return false;
+
+      boolean this_present_timeout = true;
+      boolean that_present_timeout = true;
+      if (this_present_timeout || that_present_timeout) {
+        if (!(this_present_timeout && that_present_timeout))
+          return false;
+        if (this.timeout != that.timeout)
+          return false;
+      }
+
+      return true;
+    }
+
+    @Override
+    public int hashCode() {
+      return 0;
+    }
+
+    public int compareTo(startShortWithTimeout_args other) {
+      if (!getClass().equals(other.getClass())) {
+        return getClass().getName().compareTo(other.getClass().getName());
+      }
+
+      int lastComparison = 0;
+      startShortWithTimeout_args typedOther = (startShortWithTimeout_args)other;
+
+      lastComparison = Boolean.valueOf(isSetTimeout()).compareTo(typedOther.isSetTimeout());
+      if (lastComparison != 0) {
+        return lastComparison;
+      }
+      if (isSetTimeout()) {
+        lastComparison = org.apache.thrift.TBaseHelper.compareTo(this.timeout, typedOther.timeout);
+        if (lastComparison != 0) {
+          return lastComparison;
+        }
+      }
+      return 0;
+    }
+
+    public _Fields fieldForId(int fieldId) {
+      return _Fields.findByThriftId(fieldId);
+    }
+
+    public void read(org.apache.thrift.protocol.TProtocol iprot) throws org.apache.thrift.TException {
+      schemes.get(iprot.getScheme()).getScheme().read(iprot, this);
+    }
+
+    public void write(org.apache.thrift.protocol.TProtocol oprot) throws org.apache.thrift.TException {
+      schemes.get(oprot.getScheme()).getScheme().write(oprot, this);
+    }
+
+    @Override
+    public String toString() {
+      StringBuilder sb = new StringBuilder("startShortWithTimeout_args(");
+      boolean first = true;
+
+      sb.append("timeout:");
+      sb.append(this.timeout);
+      first = false;
+      sb.append(")");
+      return sb.toString();
+    }
+
+    public void validate() throws org.apache.thrift.TException {
+      // check for required fields
+      // check for sub-struct validity
+    }
+
+    private void writeObject(java.io.ObjectOutputStream out) throws java.io.IOException {
+      try {
+        write(new org.apache.thrift.protocol.TCompactProtocol(new org.apache.thrift.transport.TIOStreamTransport(out)));
+      } catch (org.apache.thrift.TException te) {
+        throw new java.io.IOException(te);
+      }
+    }
+
+    private void readObject(java.io.ObjectInputStream in) throws java.io.IOException, ClassNotFoundException {
+      try {
+        // it doesn't seem like you should have to do this, but java serialization is wacky, and doesn't call the default constructor.
+        __isset_bitfield = 0;
+        read(new org.apache.thrift.protocol.TCompactProtocol(new org.apache.thrift.transport.TIOStreamTransport(in)));
+      } catch (org.apache.thrift.TException te) {
+        throw new java.io.IOException(te);
+      }
+    }
+
+    private static class startShortWithTimeout_argsStandardSchemeFactory implements SchemeFactory {
+      public startShortWithTimeout_argsStandardScheme getScheme() {
+        return new startShortWithTimeout_argsStandardScheme();
+      }
+    }
+
+    private static class startShortWithTimeout_argsStandardScheme extends StandardScheme<startShortWithTimeout_args> {
+
+      public void read(org.apache.thrift.protocol.TProtocol iprot, startShortWithTimeout_args struct) throws org.apache.thrift.TException {
+        org.apache.thrift.protocol.TField schemeField;
+        iprot.readStructBegin();
+        while (true)
+        {
+          schemeField = iprot.readFieldBegin();
+          if (schemeField.type == org.apache.thrift.protocol.TType.STOP) { 
+            break;
+          }
+          switch (schemeField.id) {
+            case 1: // TIMEOUT
+              if (schemeField.type == org.apache.thrift.protocol.TType.I32) {
+                struct.timeout = iprot.readI32();
+                struct.setTimeoutIsSet(true);
+              } else { 
+                org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
+              }
+              break;
+            default:
+              org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
+          }
+          iprot.readFieldEnd();
+        }
+        iprot.readStructEnd();
+
+        // check for required fields of primitive type, which can't be checked in the validate method
+        struct.validate();
+      }
+
+      public void write(org.apache.thrift.protocol.TProtocol oprot, startShortWithTimeout_args struct) throws org.apache.thrift.TException {
+        struct.validate();
+
+        oprot.writeStructBegin(STRUCT_DESC);
+        oprot.writeFieldBegin(TIMEOUT_FIELD_DESC);
+        oprot.writeI32(struct.timeout);
+        oprot.writeFieldEnd();
+        oprot.writeFieldStop();
+        oprot.writeStructEnd();
+      }
+
+    }
+
+    private static class startShortWithTimeout_argsTupleSchemeFactory implements SchemeFactory {
+      public startShortWithTimeout_argsTupleScheme getScheme() {
+        return new startShortWithTimeout_argsTupleScheme();
+      }
+    }
+
+    private static class startShortWithTimeout_argsTupleScheme extends TupleScheme<startShortWithTimeout_args> {
+
+      @Override
+      public void write(org.apache.thrift.protocol.TProtocol prot, startShortWithTimeout_args struct) throws org.apache.thrift.TException {
+        TTupleProtocol oprot = (TTupleProtocol) prot;
+        BitSet optionals = new BitSet();
+        if (struct.isSetTimeout()) {
+          optionals.set(0);
+        }
+        oprot.writeBitSet(optionals, 1);
+        if (struct.isSetTimeout()) {
+          oprot.writeI32(struct.timeout);
+        }
+      }
+
+      @Override
+      public void read(org.apache.thrift.protocol.TProtocol prot, startShortWithTimeout_args struct) throws org.apache.thrift.TException {
+        TTupleProtocol iprot = (TTupleProtocol) prot;
+        BitSet incoming = iprot.readBitSet(1);
+        if (incoming.get(0)) {
+          struct.timeout = iprot.readI32();
+          struct.setTimeoutIsSet(true);
+        }
+      }
+    }
+
+  }
+
+  public static class startShortWithTimeout_result implements org.apache.thrift.TBase<startShortWithTimeout_result, startShortWithTimeout_result._Fields>, java.io.Serializable, Cloneable   {
+    private static final org.apache.thrift.protocol.TStruct STRUCT_DESC = new org.apache.thrift.protocol.TStruct("startShortWithTimeout_result");
+
+    private static final org.apache.thrift.protocol.TField SUCCESS_FIELD_DESC = new org.apache.thrift.protocol.TField("success", org.apache.thrift.protocol.TType.STRUCT, (short)0);
+    private static final org.apache.thrift.protocol.TField E_FIELD_DESC = new org.apache.thrift.protocol.TField("e", org.apache.thrift.protocol.TType.STRUCT, (short)1);
+
+    private static final Map<Class<? extends IScheme>, SchemeFactory> schemes = new HashMap<Class<? extends IScheme>, SchemeFactory>();
+    static {
+      schemes.put(StandardScheme.class, new startShortWithTimeout_resultStandardSchemeFactory());
+      schemes.put(TupleScheme.class, new startShortWithTimeout_resultTupleSchemeFactory());
+    }
+
+    public TTransaction success; // required
+    public TGenericException e; // required
+
+    /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
+    public enum _Fields implements org.apache.thrift.TFieldIdEnum {
+      SUCCESS((short)0, "success"),
+      E((short)1, "e");
+
+      private static final Map<String, _Fields> byName = new HashMap<String, _Fields>();
+
+      static {
+        for (_Fields field : EnumSet.allOf(_Fields.class)) {
+          byName.put(field.getFieldName(), field);
+        }
+      }
+
+      /**
+       * Find the _Fields constant that matches fieldId, or null if its not found.
+       */
+      public static _Fields findByThriftId(int fieldId) {
+        switch(fieldId) {
+          case 0: // SUCCESS
+            return SUCCESS;
+          case 1: // E
+            return E;
+          default:
+            return null;
+        }
+      }
+
+      /**
+       * Find the _Fields constant that matches fieldId, throwing an exception
+       * if it is not found.
+       */
+      public static _Fields findByThriftIdOrThrow(int fieldId) {
+        _Fields fields = findByThriftId(fieldId);
+        if (fields == null) throw new IllegalArgumentException("Field " + fieldId + " doesn't exist!");
+        return fields;
+      }
+
+      /**
+       * Find the _Fields constant that matches name, or null if its not found.
+       */
+      public static _Fields findByName(String name) {
+        return byName.get(name);
+      }
+
+      private final short _thriftId;
+      private final String _fieldName;
+
+      _Fields(short thriftId, String fieldName) {
+        _thriftId = thriftId;
+        _fieldName = fieldName;
+      }
+
+      public short getThriftFieldId() {
+        return _thriftId;
+      }
+
+      public String getFieldName() {
+        return _fieldName;
+      }
+    }
+
+    // isset id assignments
+    public static final Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> metaDataMap;
+    static {
+      Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> tmpMap = new EnumMap<_Fields, org.apache.thrift.meta_data.FieldMetaData>(_Fields.class);
+      tmpMap.put(_Fields.SUCCESS, new org.apache.thrift.meta_data.FieldMetaData("success", org.apache.thrift.TFieldRequirementType.DEFAULT, 
+          new org.apache.thrift.meta_data.StructMetaData(org.apache.thrift.protocol.TType.STRUCT, TTransaction.class)));
+      tmpMap.put(_Fields.E, new org.apache.thrift.meta_data.FieldMetaData("e", org.apache.thrift.TFieldRequirementType.DEFAULT, 
+          new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.STRUCT)));
+      metaDataMap = Collections.unmodifiableMap(tmpMap);
+      org.apache.thrift.meta_data.FieldMetaData.addStructMetaDataMap(startShortWithTimeout_result.class, metaDataMap);
+    }
+
+    public startShortWithTimeout_result() {
+    }
+
+    public startShortWithTimeout_result(
+      TTransaction success,
+      TGenericException e)
+    {
+      this();
+      this.success = success;
+      this.e = e;
+    }
+
+    /**
+     * Performs a deep copy on <i>other</i>.
+     */
+    public startShortWithTimeout_result(startShortWithTimeout_result other) {
+      if (other.isSetSuccess()) {
+        this.success = new TTransaction(other.success);
+      }
+      if (other.isSetE()) {
+        this.e = new TGenericException(other.e);
+      }
+    }
+
+    public startShortWithTimeout_result deepCopy() {
+      return new startShortWithTimeout_result(this);
+    }
+
+    @Override
+    public void clear() {
+      this.success = null;
+      this.e = null;
+    }
+
+    public TTransaction getSuccess() {
+      return this.success;
+    }
+
+    public startShortWithTimeout_result setSuccess(TTransaction success) {
+      this.success = success;
+      return this;
+    }
+
+    public void unsetSuccess() {
+      this.success = null;
+    }
+
+    /** Returns true if field success is set (has been assigned a value) and false otherwise */
+    public boolean isSetSuccess() {
+      return this.success != null;
+    }
+
+    public void setSuccessIsSet(boolean value) {
+      if (!value) {
+        this.success = null;
+      }
+    }
+
+    public TGenericException getE() {
+      return this.e;
+    }
+
+    public startShortWithTimeout_result setE(TGenericException e) {
+      this.e = e;
+      return this;
+    }
+
+    public void unsetE() {
+      this.e = null;
+    }
+
+    /** Returns true if field e is set (has been assigned a value) and false otherwise */
+    public boolean isSetE() {
+      return this.e != null;
+    }
+
+    public void setEIsSet(boolean value) {
+      if (!value) {
+        this.e = null;
+      }
+    }
+
+    public void setFieldValue(_Fields field, Object value) {
+      switch (field) {
+      case SUCCESS:
+        if (value == null) {
+          unsetSuccess();
+        } else {
+          setSuccess((TTransaction)value);
+        }
+        break;
+
+      case E:
+        if (value == null) {
+          unsetE();
+        } else {
+          setE((TGenericException)value);
+        }
+        break;
+
+      }
+    }
+
+    public Object getFieldValue(_Fields field) {
+      switch (field) {
+      case SUCCESS:
+        return getSuccess();
+
+      case E:
+        return getE();
+
+      }
+      throw new IllegalStateException();
+    }
+
+    /** Returns true if field corresponding to fieldID is set (has been assigned a value) and false otherwise */
+    public boolean isSet(_Fields field) {
+      if (field == null) {
+        throw new IllegalArgumentException();
+      }
+
+      switch (field) {
+      case SUCCESS:
+        return isSetSuccess();
+      case E:
+        return isSetE();
+      }
+      throw new IllegalStateException();
+    }
+
+    @Override
+    public boolean equals(Object that) {
+      if (that == null)
+        return false;
+      if (that instanceof startShortWithTimeout_result)
+        return this.equals((startShortWithTimeout_result)that);
+      return false;
+    }
+
+    public boolean equals(startShortWithTimeout_result that) {
+      if (that == null)
+        return false;
+
+      boolean this_present_success = true && this.isSetSuccess();
+      boolean that_present_success = true && that.isSetSuccess();
+      if (this_present_success || that_present_success) {
+        if (!(this_present_success && that_present_success))
+          return false;
+        if (!this.success.equals(that.success))
+          return false;
+      }
+
+      boolean this_present_e = true && this.isSetE();
+      boolean that_present_e = true && that.isSetE();
+      if (this_present_e || that_present_e) {
+        if (!(this_present_e && that_present_e))
+          return false;
+        if (!this.e.equals(that.e))
+          return false;
+      }
+
+      return true;
+    }
+
+    @Override
+    public int hashCode() {
+      return 0;
+    }
+
+    public int compareTo(startShortWithTimeout_result other) {
+      if (!getClass().equals(other.getClass())) {
+        return getClass().getName().compareTo(other.getClass().getName());
+      }
+
+      int lastComparison = 0;
+      startShortWithTimeout_result typedOther = (startShortWithTimeout_result)other;
+
+      lastComparison = Boolean.valueOf(isSetSuccess()).compareTo(typedOther.isSetSuccess());
+      if (lastComparison != 0) {
+        return lastComparison;
+      }
+      if (isSetSuccess()) {
+        lastComparison = org.apache.thrift.TBaseHelper.compareTo(this.success, typedOther.success);
+        if (lastComparison != 0) {
+          return lastComparison;
+        }
+      }
+      lastComparison = Boolean.valueOf(isSetE()).compareTo(typedOther.isSetE());
+      if (lastComparison != 0) {
+        return lastComparison;
+      }
+      if (isSetE()) {
+        lastComparison = org.apache.thrift.TBaseHelper.compareTo(this.e, typedOther.e);
+        if (lastComparison != 0) {
+          return lastComparison;
+        }
+      }
+      return 0;
+    }
+
+    public _Fields fieldForId(int fieldId) {
+      return _Fields.findByThriftId(fieldId);
+    }
+
+    public void read(org.apache.thrift.protocol.TProtocol iprot) throws org.apache.thrift.TException {
+      schemes.get(iprot.getScheme()).getScheme().read(iprot, this);
+    }
+
+    public void write(org.apache.thrift.protocol.TProtocol oprot) throws org.apache.thrift.TException {
+      schemes.get(oprot.getScheme()).getScheme().write(oprot, this);
+      }
+
+    @Override
+    public String toString() {
+      StringBuilder sb = new StringBuilder("startShortWithTimeout_result(");
+      boolean first = true;
+
+      sb.append("success:");
+      if (this.success == null) {
+        sb.append("null");
+      } else {
+        sb.append(this.success);
+      }
+      first = false;
+      if (!first) sb.append(", ");
+      sb.append("e:");
+      if (this.e == null) {
+        sb.append("null");
+      } else {
+        sb.append(this.e);
+      }
+      first = false;
+      sb.append(")");
+      return sb.toString();
+    }
+
+    public void validate() throws org.apache.thrift.TException {
+      // check for required fields
+      // check for sub-struct validity
+      if (success != null) {
+        success.validate();
+      }
+    }
+
+    private void writeObject(java.io.ObjectOutputStream out) throws java.io.IOException {
+      try {
+        write(new org.apache.thrift.protocol.TCompactProtocol(new org.apache.thrift.transport.TIOStreamTransport(out)));
+      } catch (org.apache.thrift.TException te) {
+        throw new java.io.IOException(te);
+      }
+    }
+
+    private void readObject(java.io.ObjectInputStream in) throws java.io.IOException, ClassNotFoundException {
+      try {
+        read(new org.apache.thrift.protocol.TCompactProtocol(new org.apache.thrift.transport.TIOStreamTransport(in)));
+      } catch (org.apache.thrift.TException te) {
+        throw new java.io.IOException(te);
+      }
+    }
+
+    private static class startShortWithTimeout_resultStandardSchemeFactory implements SchemeFactory {
+      public startShortWithTimeout_resultStandardScheme getScheme() {
+        return new startShortWithTimeout_resultStandardScheme();
+      }
+    }
+
+    private static class startShortWithTimeout_resultStandardScheme extends StandardScheme<startShortWithTimeout_result> {
+
+      public void read(org.apache.thrift.protocol.TProtocol iprot, startShortWithTimeout_result struct) throws org.apache.thrift.TException {
+        org.apache.thrift.protocol.TField schemeField;
+        iprot.readStructBegin();
+        while (true)
+        {
+          schemeField = iprot.readFieldBegin();
+          if (schemeField.type == org.apache.thrift.protocol.TType.STOP) { 
+            break;
+          }
+          switch (schemeField.id) {
+            case 0: // SUCCESS
+              if (schemeField.type == org.apache.thrift.protocol.TType.STRUCT) {
+                struct.success = new TTransaction();
+                struct.success.read(iprot);
+                struct.setSuccessIsSet(true);
+              } else { 
+                org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
+              }
+              break;
+            case 1: // E
+              if (schemeField.type == org.apache.thrift.protocol.TType.STRUCT) {
+                struct.e = new TGenericException();
+                struct.e.read(iprot);
+                struct.setEIsSet(true);
+              } else { 
+                org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
+              }
+              break;
+            default:
+              org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
+          }
+          iprot.readFieldEnd();
+        }
+        iprot.readStructEnd();
+
+        // check for required fields of primitive type, which can't be checked in the validate method
+        struct.validate();
+      }
+
+      public void write(org.apache.thrift.protocol.TProtocol oprot, startShortWithTimeout_result struct) throws org.apache.thrift.TException {
+        struct.validate();
+
+        oprot.writeStructBegin(STRUCT_DESC);
+        if (struct.success != null) {
+          oprot.writeFieldBegin(SUCCESS_FIELD_DESC);
+          struct.success.write(oprot);
+          oprot.writeFieldEnd();
+        }
+        if (struct.e != null) {
+          oprot.writeFieldBegin(E_FIELD_DESC);
+          struct.e.write(oprot);
+          oprot.writeFieldEnd();
+        }
+        oprot.writeFieldStop();
+        oprot.writeStructEnd();
+      }
+
+    }
+
+    private static class startShortWithTimeout_resultTupleSchemeFactory implements SchemeFactory {
+      public startShortWithTimeout_resultTupleScheme getScheme() {
+        return new startShortWithTimeout_resultTupleScheme();
+      }
+    }
+
+    private static class startShortWithTimeout_resultTupleScheme extends TupleScheme<startShortWithTimeout_result> {
+
+      @Override
+      public void write(org.apache.thrift.protocol.TProtocol prot, startShortWithTimeout_result struct) throws org.apache.thrift.TException {
+        TTupleProtocol oprot = (TTupleProtocol) prot;
+        BitSet optionals = new BitSet();
+        if (struct.isSetSuccess()) {
+          optionals.set(0);
+        }
+        if (struct.isSetE()) {
+          optionals.set(1);
+        }
+        oprot.writeBitSet(optionals, 2);
+        if (struct.isSetSuccess()) {
+          struct.success.write(oprot);
+        }
+        if (struct.isSetE()) {
+          struct.e.write(oprot);
+        }
+      }
+
+      @Override
+      public void read(org.apache.thrift.protocol.TProtocol prot, startShortWithTimeout_result struct) throws org.apache.thrift.TException {
+        TTupleProtocol iprot = (TTupleProtocol) prot;
+        BitSet incoming = iprot.readBitSet(2);
+        if (incoming.get(0)) {
+          struct.success = new TTransaction();
+          struct.success.read(iprot);
+          struct.setSuccessIsSet(true);
+        }
+        if (incoming.get(1)) {
+          struct.e = new TGenericException();
+          struct.e.read(iprot);
+          struct.setEIsSet(true);
         }
       }
     }

--- a/tephra-core/src/main/java/org/apache/tephra/distributed/thrift/TTransactionType.java
+++ b/tephra-core/src/main/java/org/apache/tephra/distributed/thrift/TTransactionType.java
@@ -25,6 +25,10 @@
 package org.apache.tephra.distributed.thrift;
 
 
+import java.util.Map;
+import java.util.HashMap;
+import org.apache.thrift.TEnum;
+
 public enum TTransactionType implements org.apache.thrift.TEnum {
   SHORT(1),
   LONG(2);

--- a/tephra-core/src/main/java/org/apache/tephra/distributed/thrift/TVisibilityLevel.java
+++ b/tephra-core/src/main/java/org/apache/tephra/distributed/thrift/TVisibilityLevel.java
@@ -25,6 +25,10 @@
 package org.apache.tephra.distributed.thrift;
 
 
+import java.util.Map;
+import java.util.HashMap;
+import org.apache.thrift.TEnum;
+
 public enum TVisibilityLevel implements org.apache.thrift.TEnum {
   SNAPSHOT(1),
   SNAPSHOT_EXCLUDE_CURRENT(2),

--- a/tephra-core/src/main/thrift/README
+++ b/tephra-core/src/main/thrift/README
@@ -18,3 +18,7 @@
 
 To generate thrift classes:
 	thrift --gen java --out ../java/ transaction.thrift
+
+To add the Apache license header to the generated fiels:
+  for f in ../java/org/apache/tephra/distributed/thrift/T*.java; do mv $f nn; cat header nn > $f; rm -f nn; done
+

--- a/tephra-core/src/main/thrift/header
+++ b/tephra-core/src/main/thrift/header
@@ -16,27 +16,3 @@
  * limitations under the License.
  */
 
-package org.apache.tephra.distributed;
-
-/**
- * A retry strategy is an abstraction over how the remote tx client shuold retry operations after connection
- * failures.
- */
-public abstract class RetryStrategy {
-
-  /**
-   * Increments the number of failed attempts.
-   * @return whether another attempt should be made
-   */
-  public abstract boolean failOnce();
-
-  /**
-   * Should be called before re-attempting. This can, for instance
-   * inject a sleep time between retries. Default implementation is
-   * to do nothing.
-   */
-  public void beforeRetry() {
-    // do nothinhg
-  }
-
-}

--- a/tephra-core/src/main/thrift/transaction.thrift
+++ b/tephra-core/src/main/thrift/transaction.thrift
@@ -1,3 +1,4 @@
+/*
 #
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
@@ -15,6 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+*/
 
 namespace java org.apache.tephra.distributed.thrift
 
@@ -53,6 +55,11 @@ exception TInvalidTruncateTimeException {
   1: string message
 }
 
+exception TGenericException {
+  1: string message,
+  2: string originalExceptionClass
+}
+
 # workaround for THRIFT-1474
 struct TBoolean {
   1: bool value
@@ -62,7 +69,9 @@ service TTransactionServer {
   // temporary tx2 stuff
   TTransaction startLong(),
   TTransaction startShort(),
+  // TODO remove this as it was replaced with startShortWithTimeout in 0.10
   TTransaction startShortTimeout(1: i32 timeout),
+  TTransaction startShortWithTimeout(1: i32 timeout) throws (1:TGenericException e),
   TBoolean canCommitTx(1: TTransaction tx, 2: set<binary> changes) throws (1:TTransactionNotInProgressException e),
   TBoolean commitTx(1: TTransaction tx) throws (1:TTransactionNotInProgressException e),
   void abortTx(1: TTransaction tx),

--- a/tephra-core/src/test/java/org/apache/tephra/TransactionSystemTest.java
+++ b/tephra-core/src/test/java/org/apache/tephra/TransactionSystemTest.java
@@ -33,25 +33,33 @@ import java.util.concurrent.TimeUnit;
  */
 public abstract class TransactionSystemTest {
 
-  public static final byte[] C1 = new byte[] { 'c', '1' };
-  public static final byte[] C2 = new byte[] { 'c', '2' };
-  public static final byte[] C3 = new byte[] { 'c', '3' };
-  public static final byte[] C4 = new byte[] { 'c', '4' };
+  private static final byte[] C1 = new byte[] { 'c', '1' };
+  private static final byte[] C2 = new byte[] { 'c', '2' };
+  private static final byte[] C3 = new byte[] { 'c', '3' };
+  private static final byte[] C4 = new byte[] { 'c', '4' };
 
   protected abstract TransactionSystemClient getClient() throws Exception;
 
   protected abstract TransactionStateStorage getStateStorage() throws Exception;
 
-  // Unfortunately, in-memory mode and thrift mode throw different exceptions here
-  @Test(expected = Exception.class)
+  @Test // can't do (expected=IllegalArgumentException) because the subclass needs to perform an extra assert
   public void testNegativeTimeout() throws Exception {
-    getClient().startShort(-1);
+    try {
+      getClient().startShort(-1);
+      Assert.fail("Expected illegal argument for negative timeout");
+    } catch (IllegalArgumentException e) {
+      // expected
+    }
   }
 
-  // Unfortunately, in-memory mode and thrift mode throw different exceptions here
-  @Test(expected = Exception.class)
+  @Test // can't do (expected=IllegalArgumentException) because the subclass needs to perform an extra assert
   public void testExcessiveTimeout() throws Exception {
-    getClient().startShort((int) TimeUnit.DAYS.toSeconds(10));
+    try {
+      getClient().startShort((int) TimeUnit.DAYS.toSeconds(10));
+      Assert.fail("Expected illegal argument for excessive timeout");
+    } catch (IllegalArgumentException e) {
+      // expected
+    }
   }
 
   @Test


### PR DESCRIPTION
… consistently for invalid timeout values.

Previously, it was throwing IllegalArgumentException in-memory and Exception for thrift mode. 

This breaks down into:
- adding a new exception to the thrift stubs to be able to communicate back any exception
- adding a new method startShortWithTimeout that throws that exception
- modifying the TransactionServiceThriftClient to convert that exception back into an IllegalArgumentException
- modifying the TransactionSystemTest to expect IllegalArgumentException now
- modifying the ThriftTransactionServerTest to use a retry strategy that counts retries and validate that the number of retries is 0 if startShort() throws IllegalArgumentException
- modifying TransactionServiceClient to accept a class name as the retry strategy provider (needed for above test case)
- some unrelated but reasonable style fixes


