### PR TITLE
Transaction pruning service

### DIFF
--- a/tephra-core/src/main/java/org/apache/tephra/TxConstants.java
+++ b/tephra-core/src/main/java/org/apache/tephra/TxConstants.java
@@ -354,13 +354,35 @@ public class TxConstants {
   }
 
   /**
-   * Configuration for data janitor
+   * Configuration for invalid transaction pruning
    */
-  public static final class DataJanitor {
+  public static final class TransactionPruning {
+    /**
+     * Flag to enable automatic invalid transaction pruning.
+     */
     public static final String PRUNE_ENABLE = "data.tx.prune.enable";
+    /**
+     * The table used to store intermediate state when pruning is enabled.
+     */
     public static final String PRUNE_STATE_TABLE = "data.tx.prune.state.table";
+    /**
+     * Interval in seconds to schedule prune run.
+     */
+    public static final String PRUNE_INTERVAL = "data.tx.prune.interval";
+    /**
+     * Comma separated list of invalid transaction pruning plugins to load
+     */
+    public static final String PLUGINS = "data.tx.prune.plugins";
+    /**
+     * Class name for the plugins will be plugin-name + ".class" suffix
+     */
+    public static final String PLUGIN_CLASS_SUFFIX = ".class";
 
     public static final boolean DEFAULT_PRUNE_ENABLE = false;
     public static final String DEFAULT_PRUNE_STATE_TABLE = "data_tx_janitor_state";
+    public static final long DEFAULT_PRUNE_INTERVAL = TimeUnit.HOURS.toSeconds(6);
+    public static final String DEFAULT_PLUGIN = "data.tx.prune.plugin.default";
+    public static final String DEFAULT_PLUGIN_CLASS =
+      "org.apache.tephra.hbase.txprune.HBaseTransactionPruningPlugin";
   }
 }

--- a/tephra-core/src/main/java/org/apache/tephra/TxConstants.java
+++ b/tephra-core/src/main/java/org/apache/tephra/TxConstants.java
@@ -158,6 +158,14 @@ public class TxConstants {
      * The default value for the transaction timeout limit, in seconds: unlimited.
      */
     public static final int DEFAULT_TX_MAX_TIMEOUT = Integer.MAX_VALUE;
+    /**
+     * The maximum time in seconds that a transaction can be used for data writes.
+     */
+    public static final String CFG_TX_MAX_LIFETIME = "data.tx.max.lifetime";
+    /**
+     * The default value for the maximum transaction lifetime.
+     */
+    public static final int DEFAULT_TX_MAX_LIFETIME = (int) TimeUnit.HOURS.toSeconds(25);
     /** The frequency (in seconds) to perform periodic snapshots, or 0 for no periodic snapshots. */
     public static final String CFG_TX_SNAPSHOT_INTERVAL = "data.tx.snapshot.interval";
     /** Default value for frequency of periodic snapshots of transaction state. */

--- a/tephra-core/src/main/java/org/apache/tephra/txprune/TransactionPruningPlugin.java
+++ b/tephra-core/src/main/java/org/apache/tephra/txprune/TransactionPruningPlugin.java
@@ -17,14 +17,15 @@
  * under the License.
  */
 
-package org.apache.tephra.janitor;
+package org.apache.tephra.txprune;
 
+import com.google.common.annotations.Beta;
 import org.apache.hadoop.conf.Configuration;
 
 import java.io.IOException;
 
 /**
- * Data janitor interface to manage the invalid transaction list.
+ * Interface to manage the invalid transaction list.
  *
  * <p/>
  * An invalid transaction can only be removed from the invalid list after the data written
@@ -36,17 +37,13 @@ import java.io.IOException;
  * Typically every data store will have a background job which cleans up the data written by invalid transactions.
  * Prune upper bound for a data store is defined as the largest invalid transaction whose data has been
  * cleaned up from that data store.
- * <pre>
- * prune-upper-bound = min(max(invalid list), min(in-progress list) - 1)
- * </pre>
- * where invalid list and in-progress list are from the transaction snapshot used to clean up the invalid data in the
- * data store.
  *
  * <p/>
  * There will be one such plugin per data store. The plugins will be executed as part of the Transaction Service.
  * Each plugin will be invoked periodically to fetch the prune upper bound for its data store.
  * Invalid transaction list can pruned up to the minimum of prune upper bounds returned by all the plugins.
  */
+@Beta
 public interface TransactionPruningPlugin {
   /**
    * Called once when the Transaction Service starts up.

--- a/tephra-core/src/main/java/org/apache/tephra/txprune/TransactionPruningRunnable.java
+++ b/tephra-core/src/main/java/org/apache/tephra/txprune/TransactionPruningRunnable.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.tephra.txprune;
+
+import com.google.common.annotations.VisibleForTesting;
+import org.apache.tephra.Transaction;
+import org.apache.tephra.TransactionManager;
+import org.apache.tephra.util.TxUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeSet;
+
+/**
+ * This class executes one run of transaction pruning every time it is invoked.
+ * Typically, this class will be scheduled to run periodically.
+ */
+public class TransactionPruningRunnable implements Runnable {
+  private static final Logger LOG = LoggerFactory.getLogger(TransactionPruningRunnable.class);
+
+  private final TransactionManager txManager;
+  private final Map<String, TransactionPruningPlugin> plugins;
+  private final long txMaxLifetimeMillis;
+
+  public TransactionPruningRunnable(TransactionManager txManager, Map<String, TransactionPruningPlugin> plugins,
+                                    long txMaxLifetimeMillis) {
+    this.txManager = txManager;
+    this.plugins = plugins;
+    this.txMaxLifetimeMillis = txMaxLifetimeMillis;
+  }
+
+  @Override
+  public void run() {
+    try {
+      // TODO: TEPHRA-159 Start a read only transaction here
+      Transaction tx = txManager.startShort();
+      txManager.abort(tx);
+
+      long now = getTime();
+      long inactiveTransactionBound = TxUtils.getInactiveTxBound(now, txMaxLifetimeMillis);
+      LOG.info("Starting invalid prune run for time {} and inactive transaction bound {}",
+               now, inactiveTransactionBound);
+
+      List<Long> pruneUpperBounds = new ArrayList<>();
+      for (Map.Entry<String, TransactionPruningPlugin> entry : plugins.entrySet()) {
+        String name = entry.getKey();
+        TransactionPruningPlugin plugin = entry.getValue();
+        try {
+          LOG.debug("Fetching prune upper bound using plugin {}", name);
+          long pruneUpperBound = plugin.fetchPruneUpperBound(now, inactiveTransactionBound);
+          LOG.debug("Got prune upper bound {} from plugin {}", pruneUpperBound, name);
+          pruneUpperBounds.add(pruneUpperBound);
+        } catch (Exception e) {
+          LOG.error("Aborting invalid prune run for time {} due to exception from plugin {}", now, name, e);
+          return;
+        }
+      }
+
+      long minPruneUpperBound = Collections.min(pruneUpperBounds);
+      LOG.info("Got minimum prune upper bound {} across all plugins", minPruneUpperBound);
+      if (minPruneUpperBound <= 0) {
+        LOG.info("Not pruning invalid list since minimum prune upper bound ({}) is less than 1", minPruneUpperBound);
+        return;
+      }
+
+      long[] invalids = tx.getInvalids();
+      TreeSet<Long> toTruncate = new TreeSet<>();
+      LOG.debug("Invalid list: {}", invalids);
+      for (long invalid : invalids) {
+        if (invalid <= minPruneUpperBound) {
+          toTruncate.add(invalid);
+        }
+      }
+      if (toTruncate.isEmpty()) {
+        LOG.info("Not pruning invalid list since no invalid id is less than or equal to the minimum prune upper bound");
+        return;
+      }
+
+      LOG.debug("Removing the following invalid ids from the invalid list", toTruncate);
+      txManager.truncateInvalidTx(toTruncate);
+      LOG.info("Removed {} invalid ids from the invalid list", toTruncate.size());
+
+      // Call prune complete on all plugins
+      Long maxPrunedInvalid = toTruncate.last();
+      for (Map.Entry<String, TransactionPruningPlugin> entry : plugins.entrySet()) {
+        String name = entry.getKey();
+        TransactionPruningPlugin plugin = entry.getValue();
+        try {
+          LOG.debug("Calling prune complete on plugin {}", name);
+          plugin.pruneComplete(now, maxPrunedInvalid);
+        } catch (Exception e) {
+          // Ignore any exceptions and continue with other plugins
+          LOG.error("Got error while calling prune complete on plugin {}", name, e);
+        }
+      }
+
+      LOG.info("Invalid prune run for time {} is complete", now);
+    } catch (Exception e) {
+      LOG.error("Got exception during invalid list prune run", e);
+    }
+  }
+
+  @VisibleForTesting
+  long getTime() {
+    return System.currentTimeMillis();
+  }
+}

--- a/tephra-core/src/main/java/org/apache/tephra/txprune/TransactionPruningService.java
+++ b/tephra-core/src/main/java/org/apache/tephra/txprune/TransactionPruningService.java
@@ -1,0 +1,144 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.tephra.txprune;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.util.concurrent.AbstractIdleService;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.tephra.TransactionManager;
+import org.apache.tephra.TxConstants;
+import org.apache.twill.internal.utils.Instances;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Service to prune the invalid list periodically.
+ */
+public class TransactionPruningService extends AbstractIdleService {
+  private static final Logger LOG = LoggerFactory.getLogger(TransactionPruningService.class);
+
+  private final Configuration conf;
+  private final TransactionManager txManager;
+  private final long scheduleInterval;
+  private final boolean pruneEnabled;
+  private ScheduledExecutorService scheduledExecutorService;
+
+  public TransactionPruningService(Configuration conf, TransactionManager txManager) {
+    this.conf = conf;
+    this.txManager = txManager;
+    this.pruneEnabled = conf.getBoolean(TxConstants.TransactionPruning.PRUNE_ENABLE,
+                                        TxConstants.TransactionPruning.DEFAULT_PRUNE_ENABLE);
+    this.scheduleInterval = conf.getLong(TxConstants.TransactionPruning.PRUNE_INTERVAL,
+                                         TxConstants.TransactionPruning.DEFAULT_PRUNE_INTERVAL);
+  }
+
+  @Override
+  protected void startUp() throws Exception {
+    if (!pruneEnabled) {
+      LOG.info("Transaction pruning is not enabled");
+      return;
+    }
+
+    LOG.info("Starting {}...", this.getClass().getSimpleName());
+    scheduledExecutorService = Executors.newSingleThreadScheduledExecutor();
+
+    Map<String, TransactionPruningPlugin> plugins = initializePlugins();
+    long txMaxLifetimeMillis = TimeUnit.SECONDS.toMillis(conf.getInt(TxConstants.Manager.CFG_TX_MAX_LIFETIME,
+                                                                     TxConstants.Manager.DEFAULT_TX_MAX_LIFETIME));
+    scheduledExecutorService.scheduleAtFixedRate(
+      getTxPruneRunnable(txManager, plugins, txMaxLifetimeMillis),
+      scheduleInterval, scheduleInterval, TimeUnit.SECONDS);
+    LOG.info("Scheduled {} plugins with interval {} seconds", plugins.size(), scheduleInterval);
+  }
+
+  @Override
+  protected void shutDown() throws Exception {
+    if (!pruneEnabled) {
+      return;
+    }
+
+    LOG.info("Stopping {}...", this.getClass().getSimpleName());
+    try {
+      scheduledExecutorService.shutdown();
+      scheduledExecutorService.awaitTermination(30, TimeUnit.SECONDS);
+    } catch (InterruptedException e) {
+      scheduledExecutorService.shutdownNow();
+      Thread.currentThread().interrupt();
+    }
+    LOG.info("Stopped {}", this.getClass().getSimpleName());
+  }
+
+  @VisibleForTesting
+  TransactionPruningRunnable getTxPruneRunnable(TransactionManager txManager,
+                                                Map<String, TransactionPruningPlugin> plugins,
+                                                long txMaxLifetimeMillis) {
+    return new TransactionPruningRunnable(txManager, plugins, txMaxLifetimeMillis);
+  }
+
+  private Map<String, TransactionPruningPlugin> initializePlugins()
+    throws ClassNotFoundException, NoSuchMethodException, IllegalAccessException, InvocationTargetException,
+    InstantiationException, IOException {
+    Map<String, TransactionPruningPlugin> initializedPlugins = new HashMap<>();
+
+    // Read set of plugin names from configuration
+    Set<String> plugins =
+      new HashSet<>(Arrays.asList(conf.getTrimmedStrings(TxConstants.TransactionPruning.PLUGINS,
+                                                         TxConstants.TransactionPruning.DEFAULT_PLUGIN)));
+
+    LOG.info("Initializing invalid list prune plugins {}", plugins);
+    for (String plugin : plugins) {
+      // Load the class for the plugin
+      // TODO: TEPHRA-205 classloader isolation for plugins
+      Class<? extends TransactionPruningPlugin> clazz = null;
+      if (TxConstants.TransactionPruning.DEFAULT_PLUGIN.equals(plugin)) {
+        Class<?> defaultClass = Class.forName(TxConstants.TransactionPruning.DEFAULT_PLUGIN_CLASS);
+        if (TransactionPruningPlugin.class.isAssignableFrom(defaultClass)) {
+          //noinspection unchecked
+          clazz = (Class<? extends TransactionPruningPlugin>) defaultClass;
+        }
+      } else {
+        clazz = conf.getClass(plugin + TxConstants.TransactionPruning.PLUGIN_CLASS_SUFFIX,
+                              null, TransactionPruningPlugin.class);
+      }
+      if (clazz == null) {
+        throw new IllegalStateException("No class specified in configuration for invalid pruning plugin " + plugin);
+      }
+      LOG.debug("Got class {} for plugin {}", clazz.getName(), plugin);
+
+      TransactionPruningPlugin instance = Instances.newInstance(clazz);
+      instance.initialize(conf);
+      LOG.debug("Plugin {} initialized", plugin);
+      initializedPlugins.put(plugin, instance);
+    }
+
+    return initializedPlugins;
+  }
+}

--- a/tephra-core/src/main/java/org/apache/tephra/util/TxUtils.java
+++ b/tephra-core/src/main/java/org/apache/tephra/util/TxUtils.java
@@ -168,6 +168,18 @@ public class TxUtils {
   }
 
   /**
+   * Returns the greatest transaction that has passed the maximum duration a transaction can be used for data writes.
+   * In other words, at <code>timeMills</code> there can be no writes from transactions equal to or smaller
+   * than the returned bound.
+   *
+   * @param timeMills time in milliseconds for which the inactive transaction bound needs to be determined
+   * @param txMaxLifetimeMillis maximum duration a transaction can be used for data writes, in milliseconds
+   */
+  public static long getInactiveTxBound(long timeMills, long txMaxLifetimeMillis) {
+    return (timeMills - txMaxLifetimeMillis) * TxConstants.MAX_TX_PER_MS - 1;
+  }
+
+  /**
    * Returns the timestamp at which the given transaction id was generated.
    *
    * @param txId transaction id

--- a/tephra-core/src/test/java/org/apache/tephra/txprune/TransactionPruningServiceTest.java
+++ b/tephra-core/src/test/java/org/apache/tephra/txprune/TransactionPruningServiceTest.java
@@ -1,0 +1,337 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.tephra.txprune;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Iterators;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.tephra.Transaction;
+import org.apache.tephra.TransactionManager;
+import org.apache.tephra.TxConstants;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Test {@link TransactionPruningService}.
+ */
+public class TransactionPruningServiceTest {
+
+  @Before
+  public void resetData() {
+    MockTxManager.getPrunedInvalidsList().clear();
+
+    MockPlugin1.getInactiveTransactionBoundList().clear();
+    MockPlugin1.getMaxPrunedInvalidList().clear();
+
+    MockPlugin2.getInactiveTransactionBoundList().clear();
+    MockPlugin2.getMaxPrunedInvalidList().clear();
+  }
+
+  @Test
+  public void testTransactionPruningService() throws Exception {
+    // Setup plugins
+    Configuration conf = new Configuration();
+    conf.set(TxConstants.TransactionPruning.PLUGINS,
+             "data.tx.txprune.plugin.mockPlugin1, data.tx.txprune.plugin.mockPlugin2");
+    conf.set("data.tx.txprune.plugin.mockPlugin1.class",
+             "org.apache.tephra.txprune.TransactionPruningServiceTest$MockPlugin1");
+    conf.set("data.tx.txprune.plugin.mockPlugin2.class",
+             "org.apache.tephra.txprune.TransactionPruningServiceTest$MockPlugin2");
+    // Setup schedule to run every second
+    conf.setBoolean(TxConstants.TransactionPruning.PRUNE_ENABLE, true);
+    conf.setInt(TxConstants.TransactionPruning.PRUNE_INTERVAL, 1);
+    conf.setInt(TxConstants.Manager.CFG_TX_MAX_LIFETIME, 10);
+
+    // Setup mock data
+    long m = 1000;
+    long n = m * TxConstants.MAX_TX_PER_MS;
+    // Current time to be returned
+    Iterator<Long> currentTime = Iterators.cycle(120L * m, 220L * m);
+    // Transaction objects to be returned by mock tx manager
+    Iterator<Transaction> txns =
+      Iterators.cycle(new Transaction(100 * n, 110 * n, new long[]{40 * n, 50 * n, 60 * n, 70 * n},
+                                      new long[]{80 * n, 90 * n}, 80 * n),
+                      new Transaction(200 * n, 210 * n, new long[]{60 * n, 75 * n, 78 * n, 100 * n, 110 * n, 120 * n},
+                                      new long[]{80 * n, 90 * n}, 80 * n));
+    // Prune upper bounds to be returned by the mock plugins
+    Iterator<Long> pruneUpperBoundsPlugin1 = Iterators.cycle(60L * n, 80L * n);
+    Iterator<Long> pruneUpperBoundsPlugin2 = Iterators.cycle(70L * n, 77L * n);
+
+    TestTransactionPruningRunnable.setCurrentTime(currentTime);
+    MockTxManager.setTxIter(txns);
+    MockPlugin1.setPruneUpperBoundIter(pruneUpperBoundsPlugin1);
+    MockPlugin2.setPruneUpperBoundIter(pruneUpperBoundsPlugin2);
+
+    MockTxManager mockTxManager = new MockTxManager(conf);
+    TransactionPruningService pruningService = new TestTransactionPruningService(conf, mockTxManager);
+    pruningService.startAndWait();
+    // This will cause the pruning run to happen three times,
+    // but we are interested in only first two runs for the assertions later
+    TimeUnit.SECONDS.sleep(3);
+    pruningService.stopAndWait();
+
+    // Assert inactive transaction bound that the plugins receive.
+    // Both the plugins should get the same inactive transaction bound since it is
+    // computed and passed by the transaction service
+    Assert.assertEquals(ImmutableList.of(110L * n - 1, 210L * n - 1),
+                        limitTwo(MockPlugin1.getInactiveTransactionBoundList()));
+    Assert.assertEquals(ImmutableList.of(110L * n - 1, 210L * n - 1),
+                        limitTwo(MockPlugin2.getInactiveTransactionBoundList()));
+
+    // Assert invalid list entries that got pruned
+    // The min prune upper bound for the first run should be 60, and for the second run 77
+    Assert.assertEquals(ImmutableList.of(ImmutableSet.of(40L * n, 50L * n, 60L * n), ImmutableSet.of(60L * n, 75L * n)),
+                        limitTwo(MockTxManager.getPrunedInvalidsList()));
+
+    // Assert max invalid tx pruned that the plugins receive for the prune complete call
+    // Both the plugins should get the same max invalid tx pruned value since it is
+    // computed and passed by the transaction service
+    Assert.assertEquals(ImmutableList.of(60L * n, 75L * n), limitTwo(MockPlugin1.getMaxPrunedInvalidList()));
+    Assert.assertEquals(ImmutableList.of(60L * n, 75L * n), limitTwo(MockPlugin2.getMaxPrunedInvalidList()));
+  }
+
+  @Test
+  public void testNoPruning() throws Exception {
+    // Setup plugins
+    Configuration conf = new Configuration();
+    conf.set(TxConstants.TransactionPruning.PLUGINS,
+             "data.tx.txprune.plugin.mockPlugin1, data.tx.txprune.plugin.mockPlugin2");
+    conf.set("data.tx.txprune.plugin.mockPlugin1.class",
+             "org.apache.tephra.txprune.TransactionPruningServiceTest$MockPlugin1");
+    conf.set("data.tx.txprune.plugin.mockPlugin2.class",
+             "org.apache.tephra.txprune.TransactionPruningServiceTest$MockPlugin2");
+    // Setup schedule to run every second
+    conf.setBoolean(TxConstants.TransactionPruning.PRUNE_ENABLE, true);
+    conf.setInt(TxConstants.TransactionPruning.PRUNE_INTERVAL, 1);
+    conf.setInt(TxConstants.Manager.CFG_TX_MAX_LIFETIME, 10);
+
+    // Setup mock data
+    long m = 1000;
+    long n = m * TxConstants.MAX_TX_PER_MS;
+    // Current time to be returned
+    Iterator<Long> currentTime = Iterators.cycle(120L * m, 220L * m);
+    // Transaction objects to be returned by mock tx manager
+    Iterator<Transaction> txns =
+      Iterators.cycle(new Transaction(100 * n, 110 * n, new long[]{40 * n, 50 * n, 60 * n, 70 * n},
+                                      new long[]{80 * n, 90 * n}, 80 * n),
+                      new Transaction(200 * n, 210 * n, new long[]{60 * n, 75 * n, 78 * n, 100 * n, 110 * n, 120 * n},
+                                      new long[]{80 * n, 90 * n}, 80 * n));
+    // Prune upper bounds to be returned by the mock plugins
+    Iterator<Long> pruneUpperBoundsPlugin1 = Iterators.cycle(35L * n, -1L);
+    Iterator<Long> pruneUpperBoundsPlugin2 = Iterators.cycle(70L * n, 100L * n);
+
+    TestTransactionPruningRunnable.setCurrentTime(currentTime);
+    MockTxManager.setTxIter(txns);
+    MockPlugin1.setPruneUpperBoundIter(pruneUpperBoundsPlugin1);
+    MockPlugin2.setPruneUpperBoundIter(pruneUpperBoundsPlugin2);
+
+    MockTxManager mockTxManager = new MockTxManager(conf);
+    TransactionPruningService pruningService = new TestTransactionPruningService(conf, mockTxManager);
+    pruningService.startAndWait();
+    // This will cause the pruning run to happen three times,
+    // but we are interested in only first two runs for the assertions later
+    TimeUnit.SECONDS.sleep(3);
+    pruningService.stopAndWait();
+
+    // Assert inactive transaction bound
+    Assert.assertEquals(ImmutableList.of(110L * n - 1, 210L * n - 1),
+                        limitTwo(MockPlugin1.getInactiveTransactionBoundList()));
+    Assert.assertEquals(ImmutableList.of(110L * n - 1, 210L * n - 1),
+                        limitTwo(MockPlugin2.getInactiveTransactionBoundList()));
+
+    // Invalid entries should not be pruned in any run
+    Assert.assertEquals(ImmutableList.of(), MockTxManager.getPrunedInvalidsList());
+
+    // No max invalid tx pruned for any run
+    Assert.assertEquals(ImmutableList.of(), limitTwo(MockPlugin1.getMaxPrunedInvalidList()));
+    Assert.assertEquals(ImmutableList.of(), limitTwo(MockPlugin2.getMaxPrunedInvalidList()));
+  }
+
+  /**
+   * Mock transaction manager for testing
+   */
+  private static class MockTxManager extends TransactionManager {
+    private static Iterator<Transaction> txIter;
+    private static List<Set<Long>> prunedInvalidsList = new ArrayList<>();
+
+    MockTxManager(Configuration config) {
+      super(config);
+    }
+
+    @Override
+    public Transaction startShort() {
+      return txIter.next();
+    }
+
+    @Override
+    public void abort(Transaction tx) {
+      // do nothing
+    }
+
+    @Override
+    public boolean truncateInvalidTx(Set<Long> invalidTxIds) {
+      prunedInvalidsList.add(invalidTxIds);
+      return true;
+    }
+
+    static void setTxIter(Iterator<Transaction> txIter) {
+      MockTxManager.txIter = txIter;
+    }
+
+    static List<Set<Long>> getPrunedInvalidsList() {
+      return prunedInvalidsList;
+    }
+  }
+
+  /**
+   * Extends {@link TransactionPruningService} to use mock time to help in testing.
+   */
+  private static class TestTransactionPruningService extends TransactionPruningService {
+    TestTransactionPruningService(Configuration conf, TransactionManager txManager) {
+      super(conf, txManager);
+    }
+
+    @Override
+    TransactionPruningRunnable getTxPruneRunnable(TransactionManager txManager,
+                                                  Map<String, TransactionPruningPlugin> plugins,
+                                                  long txMaxLifetimeMillis) {
+      return new TestTransactionPruningRunnable(txManager, plugins, txMaxLifetimeMillis);
+    }
+  }
+
+  /**
+   * Extends {@link TransactionPruningRunnable} to use mock time to help in testing.
+   */
+  private static class TestTransactionPruningRunnable extends TransactionPruningRunnable {
+    private static Iterator<Long> currentTime;
+    TestTransactionPruningRunnable(TransactionManager txManager, Map<String, TransactionPruningPlugin> plugins,
+                                   long txMaxLifetimeMillis) {
+      super(txManager, plugins, txMaxLifetimeMillis);
+    }
+
+    @Override
+    long getTime() {
+      return currentTime.next();
+    }
+
+    static void setCurrentTime(Iterator<Long> currentTime) {
+      TestTransactionPruningRunnable.currentTime = currentTime;
+    }
+  }
+
+  /**
+   * Mock transaction pruning plugin for testing.
+   */
+  private static class MockPlugin1 implements TransactionPruningPlugin {
+    private static Iterator<Long> pruneUpperBoundIter;
+    private static List<Long> inactiveTransactionBoundList = new ArrayList<>();
+    private static List<Long> maxPrunedInvalidList = new ArrayList<>();
+
+    @Override
+    public void initialize(Configuration conf) throws IOException {
+      // Nothing to do
+    }
+
+    @Override
+    public long fetchPruneUpperBound(long time, long inactiveTransactionBound) throws IOException {
+      inactiveTransactionBoundList.add(inactiveTransactionBound);
+      return pruneUpperBoundIter.next();
+    }
+
+    @Override
+    public void pruneComplete(long time, long maxPrunedInvalid) throws IOException {
+      maxPrunedInvalidList.add(maxPrunedInvalid);
+    }
+
+    @Override
+    public void destroy() {
+      // Nothing to do
+    }
+
+    static void setPruneUpperBoundIter(Iterator<Long> pruneUpperBoundIter) {
+      MockPlugin1.pruneUpperBoundIter = pruneUpperBoundIter;
+    }
+
+    static List<Long> getInactiveTransactionBoundList() {
+      return inactiveTransactionBoundList;
+    }
+
+    static List<Long> getMaxPrunedInvalidList() {
+      return maxPrunedInvalidList;
+    }
+  }
+
+  /**
+   * Mock transaction pruning plugin for testing.
+   */
+  private static class MockPlugin2 implements TransactionPruningPlugin {
+    private static Iterator<Long> pruneUpperBoundIter;
+    private static List<Long> inactiveTransactionBoundList = new ArrayList<>();
+    private static List<Long> maxPrunedInvalidList = new ArrayList<>();
+
+    @Override
+    public void initialize(Configuration conf) throws IOException {
+      // Nothing to do
+    }
+
+    @Override
+    public long fetchPruneUpperBound(long time, long inactiveTransactionBound) throws IOException {
+      inactiveTransactionBoundList.add(inactiveTransactionBound);
+      return pruneUpperBoundIter.next();
+    }
+
+    @Override
+    public void pruneComplete(long time, long maxPrunedInvalid) throws IOException {
+      maxPrunedInvalidList.add(maxPrunedInvalid);
+    }
+
+    @Override
+    public void destroy() {
+      // Nothing to do
+    }
+
+    static void setPruneUpperBoundIter(Iterator<Long> pruneUpperBoundIter) {
+      MockPlugin2.pruneUpperBoundIter = pruneUpperBoundIter;
+    }
+
+    static List<Long> getInactiveTransactionBoundList() {
+      return inactiveTransactionBoundList;
+    }
+
+    static List<Long> getMaxPrunedInvalidList() {
+      return maxPrunedInvalidList;
+    }
+  }
+
+  private static <T> List<T> limitTwo(Iterable<T> iterable) {
+    return ImmutableList.copyOf(Iterables.limit(iterable, 2));
+  }
+}

--- a/tephra-hbase-compat-1.1-base/src/main/java/org/apache/tephra/hbase/TransactionAwareHTable.java
+++ b/tephra-hbase-compat-1.1-base/src/main/java/org/apache/tephra/hbase/TransactionAwareHTable.java
@@ -649,6 +649,7 @@ public class TransactionAwareHTable extends AbstractTransactionAwareTable
         txDelete.setAttribute(entry.getKey(), entry.getValue());
     }
     txDelete.setDurability(delete.getDurability());
+    addToOperation(txDelete, tx);
     return txDelete;
   }
 

--- a/tephra-hbase-compat-1.1-base/src/main/java/org/apache/tephra/hbase/coprocessor/TransactionProcessor.java
+++ b/tephra-hbase-compat-1.1-base/src/main/java/org/apache/tephra/hbase/coprocessor/TransactionProcessor.java
@@ -57,7 +57,7 @@ import org.apache.tephra.TransactionCodec;
 import org.apache.tephra.TxConstants;
 import org.apache.tephra.coprocessor.TransactionStateCache;
 import org.apache.tephra.coprocessor.TransactionStateCacheSupplier;
-import org.apache.tephra.hbase.coprocessor.janitor.CompactionState;
+import org.apache.tephra.hbase.txprune.CompactionState;
 import org.apache.tephra.persist.TransactionVisibilityState;
 import org.apache.tephra.util.TxUtils;
 
@@ -151,12 +151,12 @@ public class TransactionProcessor extends BaseRegionObserver {
         TimeUnit.SECONDS.toMillis(env.getConfiguration().getInt(TxConstants.Manager.CFG_TX_MAX_LIFETIME,
                                                                 TxConstants.Manager.DEFAULT_TX_MAX_LIFETIME));
 
-      boolean pruneEnabled = env.getConfiguration().getBoolean(TxConstants.DataJanitor.PRUNE_ENABLE,
-                                                               TxConstants.DataJanitor.DEFAULT_PRUNE_ENABLE);
+      boolean pruneEnabled = env.getConfiguration().getBoolean(TxConstants.TransactionPruning.PRUNE_ENABLE,
+                                                               TxConstants.TransactionPruning.DEFAULT_PRUNE_ENABLE);
       if (pruneEnabled) {
-        String pruneTable = env.getConfiguration().get(TxConstants.DataJanitor.PRUNE_STATE_TABLE,
-                                                       TxConstants.DataJanitor.DEFAULT_PRUNE_STATE_TABLE);
-        compactionState = new CompactionState(env, TableName.valueOf(pruneTable));
+        String pruneTable = env.getConfiguration().get(TxConstants.TransactionPruning.PRUNE_STATE_TABLE,
+                                                       TxConstants.TransactionPruning.DEFAULT_PRUNE_STATE_TABLE);
+        compactionState = new CompactionState(env, TableName.valueOf(pruneTable), txMaxLifetimeMillis);
         LOG.debug("Automatic invalid list pruning is enabled. Compaction state will be recorded in table " +
                     pruneTable);
       }

--- a/tephra-hbase-compat-1.1-base/src/main/java/org/apache/tephra/hbase/txprune/CompactionState.java
+++ b/tephra-hbase-compat-1.1-base/src/main/java/org/apache/tephra/hbase/txprune/CompactionState.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package org.apache.tephra.hbase.coprocessor.janitor;
+package org.apache.tephra.hbase.txprune;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -41,13 +41,15 @@ public class CompactionState {
   private final byte[] regionName;
   private final String regionNameAsString;
   private final TableName stateTable;
+  private final long txMaxLifetimeMills;
   private final DataJanitorState dataJanitorState;
   private volatile long pruneUpperBound = -1;
 
-  public CompactionState(final RegionCoprocessorEnvironment env, final TableName stateTable) {
+  public CompactionState(final RegionCoprocessorEnvironment env, final TableName stateTable, long txMaxLifetimeMills) {
     this.regionName = env.getRegionInfo().getRegionName();
     this.regionNameAsString = env.getRegionInfo().getRegionNameAsString();
     this.stateTable = stateTable;
+    this.txMaxLifetimeMills = txMaxLifetimeMills;
     this.dataJanitorState = new DataJanitorState(new DataJanitorState.TableSupplier() {
       @Override
       public Table get() throws IOException {

--- a/tephra-hbase-compat-1.1-base/src/main/java/org/apache/tephra/hbase/txprune/DataJanitorState.java
+++ b/tephra-hbase-compat-1.1-base/src/main/java/org/apache/tephra/hbase/txprune/DataJanitorState.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package org.apache.tephra.hbase.coprocessor.janitor;
+package org.apache.tephra.hbase.txprune;
 
 import com.google.common.collect.Maps;
 import org.apache.hadoop.hbase.client.Delete;

--- a/tephra-hbase-compat-1.1-base/src/main/java/org/apache/tephra/hbase/txprune/HBaseTransactionPruningPlugin.java
+++ b/tephra-hbase-compat-1.1-base/src/main/java/org/apache/tephra/hbase/txprune/HBaseTransactionPruningPlugin.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package org.apache.tephra.hbase.coprocessor.janitor;
+package org.apache.tephra.hbase.txprune;
 
 import com.google.common.base.Function;
 import com.google.common.collect.Iterables;
@@ -34,7 +34,7 @@ import org.apache.hadoop.hbase.client.Table;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.tephra.TxConstants;
 import org.apache.tephra.hbase.coprocessor.TransactionProcessor;
-import org.apache.tephra.janitor.TransactionPruningPlugin;
+import org.apache.tephra.txprune.TransactionPruningPlugin;
 import org.apache.tephra.util.TxUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -120,8 +120,8 @@ public class HBaseTransactionPruningPlugin implements TransactionPruningPlugin {
     this.conf = conf;
     this.connection = ConnectionFactory.createConnection(conf);
 
-    final TableName stateTable = TableName.valueOf(conf.get(TxConstants.DataJanitor.PRUNE_STATE_TABLE,
-                                                            TxConstants.DataJanitor.DEFAULT_PRUNE_STATE_TABLE));
+    final TableName stateTable = TableName.valueOf(conf.get(TxConstants.TransactionPruning.PRUNE_STATE_TABLE,
+                                                            TxConstants.TransactionPruning.DEFAULT_PRUNE_STATE_TABLE));
     LOG.info("Initializing plugin with state table {}", stateTable.getNameWithNamespaceInclAsString());
     this.dataJanitorState = new DataJanitorState(new DataJanitorState.TableSupplier() {
       @Override

--- a/tephra-hbase-compat-1.1-base/src/main/java/org/apache/tephra/hbase/txprune/TimeRegions.java
+++ b/tephra-hbase-compat-1.1-base/src/main/java/org/apache/tephra/hbase/txprune/TimeRegions.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package org.apache.tephra.hbase.coprocessor.janitor;
+package org.apache.tephra.hbase.txprune;
 
 import com.google.common.base.Function;
 import com.google.common.base.Joiner;

--- a/tephra-hbase-compat-1.1-base/src/test/java/org/apache/tephra/hbase/txprune/DataJanitorStateTest.java
+++ b/tephra-hbase-compat-1.1-base/src/test/java/org/apache/tephra/hbase/txprune/DataJanitorStateTest.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package org.apache.tephra.hbase.coprocessor.janitor;
+package org.apache.tephra.hbase.txprune;
 
 
 import com.google.common.collect.ImmutableSortedMap;
@@ -51,8 +51,8 @@ public class DataJanitorStateTest extends AbstractHBaseTableTest {
 
   @Before
   public void beforeTest() throws Exception {
-    pruneStateTable = TableName.valueOf(conf.get(TxConstants.DataJanitor.PRUNE_STATE_TABLE,
-                                                 TxConstants.DataJanitor.DEFAULT_PRUNE_STATE_TABLE));
+    pruneStateTable = TableName.valueOf(conf.get(TxConstants.TransactionPruning.PRUNE_STATE_TABLE,
+                                                 TxConstants.TransactionPruning.DEFAULT_PRUNE_STATE_TABLE));
     HTable table = createTable(pruneStateTable.getName(), new byte[][]{DataJanitorState.FAMILY}, false,
                                // Prune state table is a non-transactional table, hence no transaction co-processor
                                Collections.<String>emptyList());

--- a/tephra-hbase-compat-1.1-base/src/test/java/org/apache/tephra/hbase/txprune/InvalidListPruneTest.java
+++ b/tephra-hbase-compat-1.1-base/src/test/java/org/apache/tephra/hbase/txprune/InvalidListPruneTest.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package org.apache.tephra.hbase.coprocessor.janitor;
+package org.apache.tephra.hbase.txprune;
 
 import com.google.common.base.Supplier;
 import com.google.common.collect.ImmutableSet;
@@ -44,12 +44,12 @@ import org.apache.tephra.hbase.AbstractHBaseTableTest;
 import org.apache.tephra.hbase.TransactionAwareHTable;
 import org.apache.tephra.hbase.coprocessor.TransactionProcessor;
 import org.apache.tephra.inmemory.InMemoryTxSystemClient;
-import org.apache.tephra.janitor.TransactionPruningPlugin;
 import org.apache.tephra.metrics.TxMetricsCollector;
 import org.apache.tephra.persist.InMemoryTransactionStateStorage;
 import org.apache.tephra.persist.TransactionSnapshot;
 import org.apache.tephra.persist.TransactionStateStorage;
 import org.apache.tephra.persist.TransactionVisibilityState;
+import org.apache.tephra.txprune.TransactionPruningPlugin;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -77,7 +77,7 @@ public class InvalidListPruneTest extends AbstractHBaseTableTest {
   public static void startMiniCluster() throws Exception {
     // Setup the configuration to start HBase cluster with the invalid list pruning enabled
     conf = HBaseConfiguration.create();
-    conf.setBoolean(TxConstants.DataJanitor.PRUNE_ENABLE, true);
+    conf.setBoolean(TxConstants.TransactionPruning.PRUNE_ENABLE, true);
     AbstractHBaseTableTest.startMiniCluster();
 
     TransactionStateStorage txStateStorage = new InMemoryTransactionStateStorage();
@@ -100,8 +100,8 @@ public class InvalidListPruneTest extends AbstractHBaseTableTest {
     testUtil.flush(txDataTable1);
     txManager.stopAndWait();
 
-    pruneStateTable = TableName.valueOf(conf.get(TxConstants.DataJanitor.PRUNE_STATE_TABLE,
-                                                 TxConstants.DataJanitor.DEFAULT_PRUNE_STATE_TABLE));
+    pruneStateTable = TableName.valueOf(conf.get(TxConstants.TransactionPruning.PRUNE_STATE_TABLE,
+                                                 TxConstants.TransactionPruning.DEFAULT_PRUNE_STATE_TABLE));
   }
 
   @AfterClass


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TEPHRA-203
https://issues.apache.org/jira/browse/TEPHRA-199

This PR has three things -
 * Define and enforce maximum transaction lifetime where transactions can be used for data writes
 * Add `TransactionPruningService` to periodically schedule transaction prune run
* Rename package name janitor to txprune

It would be easier to review the commits independently.
