### PR TITLE
TEPHRA-223 Encapsulate the two data structures used for invalid transactions to avoid update issues

### DIFF
--- a/tephra-core/src/main/java/org/apache/tephra/manager/InvalidTxList.java
+++ b/tephra-core/src/main/java/org/apache/tephra/manager/InvalidTxList.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.tephra.manager;
+
+import it.unimi.dsi.fastutil.longs.LongArrayList;
+import it.unimi.dsi.fastutil.longs.LongList;
+import it.unimi.dsi.fastutil.longs.LongLists;
+import org.apache.tephra.TransactionManager;
+
+import java.util.Arrays;
+import java.util.Collection;
+import javax.annotation.concurrent.NotThreadSafe;
+
+/**
+ * This is an internal class used by the {@link TransactionManager} to store invalid transaction ids.
+ * This class uses both a list and an array to keep track of the invalid ids. The list is the primary
+ * data structure for storing the invalid ids. The array is populated lazily on changes to the list.
+ * The array is used to avoid creating a new array every time method {@link #toSortedArray()} is invoked.
+ *
+ * This class is not thread safe and relies on external synchronization. TransactionManager always
+ * accesses an instance of this class after synchronization.
+ */
+@NotThreadSafe
+public class InvalidTxList {
+  private static final long[] NO_INVALID_TX = { };
+
+  private final LongList invalid = new LongArrayList();
+  private long[] invalidArray = NO_INVALID_TX;
+
+  private boolean dirty = false; // used to track changes to the invalid list
+
+  public int size() {
+    return invalid.size();
+  }
+
+  public boolean isEmpty() {
+    return invalid.isEmpty();
+  }
+
+  public boolean add(long id) {
+    boolean changed = invalid.add(id);
+    dirty = dirty || changed;
+    return changed;
+  }
+
+  public boolean addAll(Collection<? extends Long> ids) {
+    boolean changed = invalid.addAll(ids);
+    dirty = dirty || changed;
+    return changed;
+  }
+
+  public boolean addAll(LongList ids) {
+    boolean changed = invalid.addAll(ids);
+    dirty = dirty || changed;
+    return changed;
+  }
+
+  public boolean contains(long id) {
+    return invalid.contains(id);
+  }
+
+  public boolean remove(long id) {
+    boolean changed = invalid.rem(id);
+    dirty = dirty || changed;
+    return changed;
+  }
+
+  public boolean removeAll(Collection<? extends Long> ids) {
+    boolean changed = invalid.removeAll(ids);
+    dirty = dirty || changed;
+    return changed;
+  }
+
+  @SuppressWarnings("WeakerAccess")
+  public boolean removeAll(LongList ids) {
+    boolean changed = invalid.removeAll(ids);
+    dirty = dirty || changed;
+    return changed;
+  }
+
+  public void clear() {
+    invalid.clear();
+    invalidArray = NO_INVALID_TX;
+    dirty = false;
+  }
+
+  /**
+   * @return sorted array of invalid transactions
+   */
+  public long[] toSortedArray() {
+    lazyUpdate();
+    return invalidArray;
+  }
+
+  /**
+   * @return list of invalid transactions. The list is not sorted.
+   */
+  public LongList toRawList() {
+    return LongLists.unmodifiable(invalid);
+  }
+
+  private void lazyUpdate() {
+    if (dirty) {
+      invalidArray = invalid.toLongArray();
+      Arrays.sort(invalidArray);
+      dirty = false;
+    }
+  }
+}

--- a/tephra-core/src/test/java/org/apache/tephra/manager/InvalidTxListTest.java
+++ b/tephra-core/src/test/java/org/apache/tephra/manager/InvalidTxListTest.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.tephra.manager;
+
+import com.google.common.collect.ImmutableList;
+import it.unimi.dsi.fastutil.longs.LongArrayList;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ *
+ */
+public class InvalidTxListTest {
+
+  @Test
+  public void testInvalidTxList() {
+    InvalidTxList invalidTxList = new InvalidTxList();
+    // Assert that the list is empty at the beginning
+    Assert.assertTrue(invalidTxList.isEmpty());
+    Assert.assertEquals(0, invalidTxList.size());
+    Assert.assertEquals(ImmutableList.of(), invalidTxList.toRawList());
+    Assert.assertArrayEquals(new long[0], invalidTxList.toSortedArray());
+
+    // Try removing something from the empty list
+    Assert.assertFalse(invalidTxList.remove(3));
+    Assert.assertFalse(invalidTxList.removeAll(ImmutableList.of(5L, 9L)));
+
+    // verify contains
+    Assert.assertFalse(invalidTxList.contains(3));
+
+    // Add some elements to the list
+    invalidTxList.add(3);
+    invalidTxList.add(1);
+    invalidTxList.add(8);
+    invalidTxList.add(5);
+
+    // verify contains
+    Assert.assertTrue(invalidTxList.contains(3));
+
+    // Assert the newly added elements
+    Assert.assertFalse(invalidTxList.isEmpty());
+    Assert.assertEquals(4, invalidTxList.size());
+    Assert.assertEquals(ImmutableList.of(3L, 1L, 8L, 5L), invalidTxList.toRawList());
+    Assert.assertArrayEquals(new long[] {1, 3, 5, 8}, invalidTxList.toSortedArray());
+
+    // Add a collection of elements
+    invalidTxList.addAll(ImmutableList.of(7L, 10L, 4L, 2L));
+
+    // Assert the newly added elements
+    Assert.assertFalse(invalidTxList.isEmpty());
+    Assert.assertEquals(8, invalidTxList.size());
+    Assert.assertEquals(ImmutableList.of(3L, 1L, 8L, 5L, 7L, 10L, 4L, 2L), invalidTxList.toRawList());
+    Assert.assertArrayEquals(new long[] {1, 2, 3, 4, 5, 7, 8, 10}, invalidTxList.toSortedArray());
+
+    // Remove elements that are not present
+    Assert.assertFalse(invalidTxList.remove(6));
+    Assert.assertFalse(invalidTxList.removeAll(ImmutableList.of(9L, 11L)));
+
+    // Remove a collection of elements
+    Assert.assertTrue(invalidTxList.removeAll(ImmutableList.of(8L, 4L, 2L)));
+    // This time check the array first and then check the list
+    Assert.assertArrayEquals(new long[] {1, 3, 5, 7, 10}, invalidTxList.toSortedArray());
+    Assert.assertEquals(ImmutableList.of(3L, 1L, 5L, 7L, 10L), invalidTxList.toRawList());
+
+    // Remove a single element
+    Assert.assertTrue(invalidTxList.remove(5));
+    Assert.assertArrayEquals(new long[] {1, 3, 7, 10}, invalidTxList.toSortedArray());
+    Assert.assertEquals(ImmutableList.of(3L, 1L, 7L, 10L), invalidTxList.toRawList());
+
+    // Add a LongCollection
+    invalidTxList.addAll(new LongArrayList(new long[] {15, 12, 13}));
+
+    // Assert the newly added elements
+    Assert.assertEquals(7, invalidTxList.size());
+    Assert.assertArrayEquals(new long[] {1, 3, 7, 10, 12, 13, 15}, invalidTxList.toSortedArray());
+    Assert.assertEquals(ImmutableList.of(3L, 1L, 7L, 10L, 15L, 12L, 13L), invalidTxList.toRawList());
+
+    // Remove a LongCollection
+    invalidTxList.removeAll(new LongArrayList(new long[] {3, 7, 12}));
+
+    // Assert removals
+    Assert.assertEquals(4, invalidTxList.size());
+    Assert.assertArrayEquals(new long[] {1, 10, 13, 15}, invalidTxList.toSortedArray());
+    Assert.assertEquals(ImmutableList.of(1L, 10L, 15L, 13L), invalidTxList.toRawList());
+
+    // Clear the list
+    invalidTxList.clear();
+    Assert.assertTrue(invalidTxList.isEmpty());
+    Assert.assertEquals(0, invalidTxList.size());
+    Assert.assertArrayEquals(new long[0], invalidTxList.toSortedArray());
+    Assert.assertEquals(ImmutableList.of(), invalidTxList.toRawList());
+  }
+}

--- a/tephra-core/src/test/java/org/apache/tephra/persist/AbstractTransactionStateStorageTest.java
+++ b/tephra-core/src/test/java/org/apache/tephra/persist/AbstractTransactionStateStorageTest.java
@@ -23,6 +23,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
+import com.google.common.primitives.Longs;
 import it.unimi.dsi.fastutil.longs.LongArrayList;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.tephra.ChangeId;
@@ -137,6 +138,9 @@ public abstract class AbstractTransactionStateStorageTest {
       // TODO: replace with new persistence tests
       final byte[] a = { 'a' };
       final byte[] b = { 'b' };
+      // Start and invalidate a transaction
+      Transaction invalid = txManager.startShort();
+      txManager.invalidate(invalid.getTransactionId());
       // start a tx1, add a change A and commit
       Transaction tx1 = txManager.startShort();
       Assert.assertTrue(txManager.canCommit(tx1, Collections.singleton(a)));
@@ -161,6 +165,12 @@ public abstract class AbstractTransactionStateStorageTest {
       TransactionSnapshot newState = txManager.getCurrentState();
       LOG.info("New state: " + newState);
       assertEquals(origState, newState);
+
+      // Verify that the invalid transaction list matches
+      Transaction checkTx = txManager.startShort();
+      Assert.assertEquals(origState.getInvalid(), Longs.asList(checkTx.getInvalids()));
+      txManager.abort(checkTx);
+      txManager.abort(invalid);
 
       // commit tx2
       Assert.assertTrue(txManager.commit(tx2));


### PR DESCRIPTION
JIRA - https://issues.apache.org/jira/browse/TEPHRA-223

Approach:
Encapsulate the invalid list and the invalidArray data structures into a class InvalidTxList. InvalidTxList tracks the changes to invalid list, and then populates invalidArray lazily when the list changes.

TODO: Add tests for class InvalidTxList