### PR TITLE
[TEPHRA-252] Fix Travis build for Oracle JDK 7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,9 @@
 
 language: java
 
+# Run it on precise, until we figure out how to make jdk7 work (or no longer support jdk7).
+dist: precise
+
 jdk:
   - oraclejdk7
   - oraclejdk8


### PR DESCRIPTION
The issue is that Travis is upgrading/upgraded to Ubuntu Trusty which does not have/support Oracle JDK 7. The fix is, for now, to explicitly require the old distro, namely "precise". 