### PR TITLE
(TEPHRA-243) Improve logging for slow log append

### DIFF
--- a/tephra-core/src/main/java/org/apache/tephra/TxConstants.java
+++ b/tephra-core/src/main/java/org/apache/tephra/TxConstants.java
@@ -384,6 +384,15 @@ public class TxConstants {
     public static final String NUM_ENTRIES_APPENDED = "count";
     public static final String VERSION_KEY = "version";
     public static final byte CURRENT_VERSION = 3;
+
+    /**
+     * Time limit, in milliseconds, of an append to the transaction log before we log it as "slow".
+     */
+    public static final String CFG_SLOW_APPEND_THRESHOLD = "data.tx.log.slow.append.threshold";
+    /**
+     * Default value for the threshold in milli seconds for slow log append warnings.
+     */
+    public static final long DEFAULT_SLOW_APPEND_THRESHOLD = 1000;
   }
 
   /**

--- a/tephra-core/src/main/java/org/apache/tephra/persist/LocalFileTransactionLog.java
+++ b/tephra-core/src/main/java/org/apache/tephra/persist/LocalFileTransactionLog.java
@@ -18,6 +18,7 @@
 
 package org.apache.tephra.persist;
 
+import org.apache.hadoop.conf.Configuration;
 import org.apache.tephra.metrics.MetricsCollector;
 
 import java.io.BufferedInputStream;
@@ -40,8 +41,8 @@ public class LocalFileTransactionLog extends AbstractTransactionLog {
    * Creates a new transaction log using the given file instance.
    * @param logFile The log file to use.
    */
-  public LocalFileTransactionLog(File logFile, long timestamp, MetricsCollector metricsCollector) {
-    super(timestamp, metricsCollector);
+  LocalFileTransactionLog(File logFile, long timestamp, MetricsCollector metricsCollector, Configuration conf) {
+    super(timestamp, metricsCollector, conf);
     this.logFile = logFile;
   }
 
@@ -64,9 +65,14 @@ public class LocalFileTransactionLog extends AbstractTransactionLog {
     private final FileOutputStream fos;
     private final DataOutputStream out;
 
-    public LogWriter(File logFile) throws IOException {
+    LogWriter(File logFile) throws IOException {
       this.fos = new FileOutputStream(logFile);
       this.out = new DataOutputStream(new BufferedOutputStream(fos, LocalFileTransactionStateStorage.BUFFER_SIZE));
+    }
+
+    @Override
+    public long getPosition() throws IOException {
+      return fos.getChannel().position();
     }
 
     @Override
@@ -97,7 +103,7 @@ public class LocalFileTransactionLog extends AbstractTransactionLog {
     private final DataInputStream in;
     private Entry reuseEntry = new Entry();
 
-    public LogReader(File logFile) throws IOException {
+    LogReader(File logFile) throws IOException {
       this.fin = new FileInputStream(logFile);
       this.in = new DataInputStream(new BufferedInputStream(fin, LocalFileTransactionStateStorage.BUFFER_SIZE));
     }

--- a/tephra-core/src/main/java/org/apache/tephra/persist/LocalFileTransactionStateStorage.java
+++ b/tephra-core/src/main/java/org/apache/tephra/persist/LocalFileTransactionStateStorage.java
@@ -61,6 +61,7 @@ public class LocalFileTransactionStateStorage extends AbstractTransactionStateSt
   };
 
   private final String configuredSnapshotDir;
+  private final Configuration conf;
   private final MetricsCollector metricsCollector;
   private File snapshotDir;
 
@@ -69,6 +70,7 @@ public class LocalFileTransactionStateStorage extends AbstractTransactionStateSt
                                           MetricsCollector metricsCollector) {
     super(codecProvider);
     this.configuredSnapshotDir = conf.get(TxConstants.Manager.CFG_TX_SNAPSHOT_LOCAL_DIR);
+    this.conf = conf;
     this.metricsCollector = metricsCollector;
   }
 
@@ -220,7 +222,7 @@ public class LocalFileTransactionStateStorage extends AbstractTransactionStateSt
       @Nullable
       @Override
       public TransactionLog apply(@Nullable TimestampedFilename input) {
-        return new LocalFileTransactionLog(input.getFile(), input.getTimestamp(), metricsCollector);
+        return new LocalFileTransactionLog(input.getFile(), input.getTimestamp(), metricsCollector, conf);
       }
     });
   }
@@ -229,7 +231,7 @@ public class LocalFileTransactionStateStorage extends AbstractTransactionStateSt
   public TransactionLog createLog(long timestamp) throws IOException {
     File newLogFile = new File(snapshotDir, LOG_FILE_PREFIX + timestamp);
     LOG.info("Creating new transaction log at {}", newLogFile.getAbsolutePath());
-    return new LocalFileTransactionLog(newLogFile, timestamp, metricsCollector);
+    return new LocalFileTransactionLog(newLogFile, timestamp, metricsCollector, conf);
   }
 
   @Override

--- a/tephra-core/src/main/java/org/apache/tephra/persist/TransactionLogWriter.java
+++ b/tephra-core/src/main/java/org/apache/tephra/persist/TransactionLogWriter.java
@@ -43,6 +43,11 @@ public interface TransactionLogWriter extends Closeable {
   void commitMarker(int count) throws IOException;
 
   /**
+   * @return the current position in the output.
+   */
+  long getPosition() throws IOException;
+
+  /**
    * Syncs any pending transaction edits added through {@link #append(AbstractTransactionLog.Entry)},
    * but not yet flushed to durable storage.
    *

--- a/tephra-core/src/test/java/org/apache/tephra/persist/HDFSTransactionLogTest.java
+++ b/tephra-core/src/test/java/org/apache/tephra/persist/HDFSTransactionLogTest.java
@@ -191,6 +191,7 @@ public class HDFSTransactionLogTest {
     List<TransactionEdit> edits = TransactionEditUtil.createRandomEdits(totalCount);
     long timestamp = System.currentTimeMillis();
     Configuration configuration = getConfiguration();
+    configuration.set(TxConstants.TransactionLog.CFG_SLOW_APPEND_THRESHOLD, "0");
     FileSystem fs = FileSystem.newInstance(FileSystem.getDefaultUri(configuration), configuration);
     SequenceFile.Writer writer = getSequenceFileWriter(configuration, fs, timestamp, versionNumber);
     AtomicLong logSequence = new AtomicLong();


### PR DESCRIPTION
- adds more detail to the log message (number of entries, bytes written)
- ensures only one thread logs the message concurrently, by moving it into the method actually writes to storage. Previously all threads logged it even if they did not write themselves 
- changed ThriftTransactionSystemTest to use LocalTransactionLog (otherwise it does not get tested at all)
- fixed a few unrelated compiler warning encountered on the way