### PR TITLE
(TEPHRA-253) Fix flaky TransactionProcessorTest

### DIFF
--- a/tephra-hbase-compat-1.0/src/test/java/org/apache/tephra/hbase/coprocessor/TransactionProcessorTest.java
+++ b/tephra-hbase-compat-1.0/src/test/java/org/apache/tephra/hbase/coprocessor/TransactionProcessorTest.java
@@ -62,6 +62,7 @@ import org.apache.tephra.snapshot.DefaultSnapshotCodec;
 import org.apache.tephra.snapshot.SnapshotCodecProvider;
 import org.apache.tephra.util.TxUtils;
 import org.junit.AfterClass;
+import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -160,7 +161,7 @@ public class TransactionProcessorTest {
     try {
       region.initialize();
       TransactionStateCache cache = new TransactionStateCacheSupplier(conf).get();
-      LOG.info("Coprocessor is using transaction state: " + cache.getLatestState());
+      LOG.info("Coprocessor is using transaction state: " + waitForTransactionState(cache));
 
       for (int i = 1; i <= 8; i++) {
         for (int k = 1; k <= i; k++) {
@@ -175,7 +176,8 @@ public class TransactionProcessorTest {
       // force a flush to clear the data
       // during flush, the coprocessor should drop all KeyValues with timestamps in the invalid set
       LOG.info("Flushing region " + region.getRegionNameAsString());
-      region.flushcache();
+      HRegion.FlushResult flushResult = region.flushcache();
+      Assert.assertTrue("Unexpected flush result: " + flushResult, flushResult.isFlushSucceeded());
 
       // now a normal scan should only return the valid rows
       // do not use a filter here to test that cleanup works on flush
@@ -217,7 +219,7 @@ public class TransactionProcessorTest {
     try {
       region.initialize();
       TransactionStateCache cache = new TransactionStateCacheSupplier(conf).get();
-      LOG.info("Coprocessor is using transaction state: " + cache.getLatestState());
+      LOG.info("Coprocessor is using transaction state: " + waitForTransactionState(cache));
 
       byte[] row = Bytes.toBytes(1);
       for (int i = 4; i < V.length; i++) {
@@ -604,6 +606,21 @@ public class TransactionProcessorTest {
     assertNotNull(cachedSnapshot);
     assertEquals(invalidSet, cachedSnapshot.getInvalid());
     cache.stopAndWait();
+  }
+
+  private TransactionVisibilityState waitForTransactionState(TransactionStateCache cache) throws InterruptedException {
+    long timeout = 5000; // ms
+    do {
+      TransactionVisibilityState state = cache.getLatestState();
+      if (state != null) {
+        return state;
+      }
+      TimeUnit.MILLISECONDS.sleep(100);
+      timeout -= 100;
+    } while (timeout > 0L);
+    LOG.error("Timed out waiting foe transaction state cache");
+    Assert.fail("Timed out waiting foe transaction state cache");
+    return null;
   }
 
   private static class LocalRegionServerServices extends MockRegionServerServices {

--- a/tephra-hbase-compat-1.1-base/src/test/java/org/apache/tephra/hbase/coprocessor/TransactionProcessorTest.java
+++ b/tephra-hbase-compat-1.1-base/src/test/java/org/apache/tephra/hbase/coprocessor/TransactionProcessorTest.java
@@ -40,6 +40,7 @@ import org.apache.hadoop.hbase.client.Put;
 import org.apache.hadoop.hbase.client.Scan;
 import org.apache.hadoop.hbase.regionserver.HRegion;
 import org.apache.hadoop.hbase.regionserver.HRegionFileSystem;
+import org.apache.hadoop.hbase.regionserver.Region;
 import org.apache.hadoop.hbase.regionserver.RegionScanner;
 import org.apache.hadoop.hbase.regionserver.ScanType;
 import org.apache.hadoop.hbase.util.Bytes;
@@ -62,6 +63,7 @@ import org.apache.tephra.snapshot.DefaultSnapshotCodec;
 import org.apache.tephra.snapshot.SnapshotCodecProvider;
 import org.apache.tephra.util.TxUtils;
 import org.junit.AfterClass;
+import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -160,7 +162,7 @@ public class TransactionProcessorTest {
     try {
       region.initialize();
       TransactionStateCache cache = new TransactionStateCacheSupplier(conf).get();
-      LOG.info("Coprocessor is using transaction state: " + cache.getLatestState());
+      LOG.info("Coprocessor is using transaction state: " + waitForTransactionState(cache));
 
       for (int i = 1; i <= 8; i++) {
         for (int k = 1; k <= i; k++) {
@@ -174,10 +176,10 @@ public class TransactionProcessorTest {
 
       // force a flush to clear the data
       // during flush, the coprocessor should drop all KeyValues with timestamps in the invalid set
-
       LOG.info("Flushing region " + region.getRegionInfo().getRegionNameAsString());
-      region.flushcache(true, false);
-
+      Region.FlushResult flushResult = region.flushcache(true, false);
+      Assert.assertTrue("Unexpected flush result: " + flushResult, flushResult.isFlushSucceeded());
+      
       // now a normal scan should only return the valid rows
       // do not use a filter here to test that cleanup works on flush
       Scan scan = new Scan();
@@ -218,7 +220,7 @@ public class TransactionProcessorTest {
     try {
       region.initialize();
       TransactionStateCache cache = new TransactionStateCacheSupplier(conf).get();
-      LOG.info("Coprocessor is using transaction state: " + cache.getLatestState());
+      LOG.info("Coprocessor is using transaction state: " + waitForTransactionState(cache));
 
       byte[] row = Bytes.toBytes(1);
       for (int i = 4; i < V.length; i++) {
@@ -606,6 +608,20 @@ public class TransactionProcessorTest {
     assertNotNull(cachedSnapshot);
     assertEquals(invalidSet, cachedSnapshot.getInvalid());
     cache.stopAndWait();
+  }
+
+  private TransactionVisibilityState waitForTransactionState(TransactionStateCache cache) throws InterruptedException {
+    long timeout = 5000; // ms
+    do {
+      TransactionVisibilityState state = cache.getLatestState();
+      if (state != null) {
+        return state;
+      }
+      TimeUnit.MILLISECONDS.sleep(100);
+      timeout -= 100;
+    } while (timeout > 0L);
+    Assert.fail("Timed out waiting foe transaction state cache");
+    return null;
   }
 
   private static class LocalRegionServerServices extends MockRegionServerServices {

--- a/tephra-hbase-compat-1.3/src/test/java/org/apache/tephra/hbase/coprocessor/TransactionProcessorTest.java
+++ b/tephra-hbase-compat-1.3/src/test/java/org/apache/tephra/hbase/coprocessor/TransactionProcessorTest.java
@@ -40,6 +40,7 @@ import org.apache.hadoop.hbase.client.Put;
 import org.apache.hadoop.hbase.client.Scan;
 import org.apache.hadoop.hbase.regionserver.HRegion;
 import org.apache.hadoop.hbase.regionserver.HRegionFileSystem;
+import org.apache.hadoop.hbase.regionserver.Region;
 import org.apache.hadoop.hbase.regionserver.RegionScanner;
 import org.apache.hadoop.hbase.regionserver.ScanType;
 import org.apache.hadoop.hbase.util.Bytes;
@@ -62,6 +63,7 @@ import org.apache.tephra.snapshot.DefaultSnapshotCodec;
 import org.apache.tephra.snapshot.SnapshotCodecProvider;
 import org.apache.tephra.util.TxUtils;
 import org.junit.AfterClass;
+import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -160,7 +162,7 @@ public class TransactionProcessorTest {
     try {
       region.initialize();
       TransactionStateCache cache = new TransactionStateCacheSupplier(conf).get();
-      LOG.info("Coprocessor is using transaction state: " + cache.getLatestState());
+      LOG.info("Coprocessor is using transaction state: " + waitForTransactionState(cache));
 
       for (int i = 1; i <= 8; i++) {
         for (int k = 1; k <= i; k++) {
@@ -176,7 +178,8 @@ public class TransactionProcessorTest {
       // during flush, the coprocessor should drop all KeyValues with timestamps in the invalid set
 
       LOG.info("Flushing region " + region.getRegionInfo().getRegionNameAsString());
-      region.flushcache(true, false);
+      Region.FlushResult flushResult = region.flushcache(true, false);
+      Assert.assertTrue("Unexpected flush result: " + flushResult, flushResult.isFlushSucceeded());
 
       // now a normal scan should only return the valid rows
       // do not use a filter here to test that cleanup works on flush
@@ -218,7 +221,7 @@ public class TransactionProcessorTest {
     try {
       region.initialize();
       TransactionStateCache cache = new TransactionStateCacheSupplier(conf).get();
-      LOG.info("Coprocessor is using transaction state: " + cache.getLatestState());
+      LOG.info("Coprocessor is using transaction state: " + waitForTransactionState(cache));
 
       byte[] row = Bytes.toBytes(1);
       for (int i = 4; i < V.length; i++) {
@@ -606,6 +609,21 @@ public class TransactionProcessorTest {
     assertNotNull(cachedSnapshot);
     assertEquals(invalidSet, cachedSnapshot.getInvalid());
     cache.stopAndWait();
+  }
+
+  private TransactionVisibilityState waitForTransactionState(TransactionStateCache cache) throws InterruptedException {
+    long timeout = 5000; // ms
+    do {
+      TransactionVisibilityState state = cache.getLatestState();
+      if (state != null) {
+        return state;
+      }
+      TimeUnit.MILLISECONDS.sleep(100);
+      timeout -= 100;
+    } while (timeout > 0L);
+    LOG.error("Timed out waiting foe transaction state cache");
+    Assert.fail("Timed out waiting foe transaction state cache");
+    return null;
   }
 
   private static class LocalRegionServerServices extends MockRegionServerServices {


### PR DESCRIPTION
Fix is to make tests wait until the transaction state is loaded, before calling flush. Same change in all compat modules. 