### PR TITLE
(TEHPRA-260) Build should not fail on Javadoc errors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -522,6 +522,14 @@
         <artifactId>maven-checkstyle-plugin</artifactId>
         <version>2.12.1</version>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <configuration>
+          <failOnError>false</failOnError>
+        </configuration>
+      </plugin>
+
     </plugins>
   </build>
 


### PR DESCRIPTION
Java 8 has much stricter Javadoc errors. Many of them are bogus, for example:
- you can't use <> inside a pre-formatted section, as in our TransactionAware class:
```
/**
 * Interface to be implemented by a component that interacts with transaction logic.
 * <pre>
 *  TransactionAware dataSet = // ...              // dataSet is one example of component that interacts with tx logic
 * ...
 *  // ... do other operations on dataSet
 *  Collection<byte[]> changes = dataSet.getTxChanges();
 * ...
 * </pre>
 */
```
Find a way to bypass these errors.