### PR TITLE
TEPHRA-263 Enforce TTL, regardless of any in-progress transactions.

### DIFF
--- a/tephra-core/src/test/java/org/apache/tephra/util/TxUtilsTest.java
+++ b/tephra-core/src/test/java/org/apache/tephra/util/TxUtilsTest.java
@@ -19,8 +19,13 @@
 package org.apache.tephra.util;
 
 import org.apache.tephra.Transaction;
+import org.apache.tephra.TxConstants;
 import org.junit.Assert;
 import org.junit.Test;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertEquals;
 
@@ -53,5 +58,35 @@ public class TxUtilsTest {
 
     tx = new Transaction(100, 110, new long[] {}, new long[] {}, Transaction.NO_TX_IN_PROGRESS);
     Assert.assertEquals(99, TxUtils.getPruneUpperBound(tx));
+  }
+
+  @Test
+  public void testTTL() {
+    long txIdsPerSecond = 1000 * TxConstants.MAX_TX_PER_MS;
+    byte[] family = new byte[] { 'd' };
+    long currentTxTimeSeconds = 100;
+    Transaction tx = new Transaction(100 * txIdsPerSecond, currentTxTimeSeconds * txIdsPerSecond,
+                                     new long[] {10 * txIdsPerSecond, 30 * txIdsPerSecond},
+                                     new long[] {80 * txIdsPerSecond, 90 * txIdsPerSecond},
+                                     80 * txIdsPerSecond);
+    int ttlSeconds = 60;
+    Map<byte[], Long> ttlByFamily = Collections.singletonMap(family, ttlSeconds * 1000L);
+    // ttl should only be impacted by the current transaction's id, and not by any older, in-progress transactions
+    Assert.assertEquals((currentTxTimeSeconds - ttlSeconds) * txIdsPerSecond,
+                        TxUtils.getOldestVisibleTimestamp(ttlByFamily, tx));
+  }
+
+  @Test
+  public void testLargeTTL() {
+    long txIdsPerSecond = 1000 * TxConstants.MAX_TX_PER_MS;
+    byte[] family = new byte[] { 'd' };
+    long currentTxTimeSeconds = 100;
+    Transaction tx = new Transaction(100 * txIdsPerSecond, currentTxTimeSeconds * txIdsPerSecond,
+                                     new long[] { }, new long[] { }, 100);
+    // ~100 years, so that the computed start timestamp is prior to 0 (epoch)
+    long ttlSeconds = TimeUnit.DAYS.toSeconds(365 * 100);
+    Map<byte[], Long> ttlByFamily = Collections.singletonMap(family, ttlSeconds * 1000L);
+    // oldest visible timestamp should be 0, not negative, because HBase timestamps can not be negative
+    Assert.assertEquals(0, TxUtils.getOldestVisibleTimestamp(ttlByFamily, tx));
   }
 }

--- a/tephra-hbase-compat-0.96/src/main/java/org/apache/tephra/hbase/coprocessor/TransactionFilters.java
+++ b/tephra-hbase-compat-0.96/src/main/java/org/apache/tephra/hbase/coprocessor/TransactionFilters.java
@@ -40,7 +40,8 @@ public class TransactionFilters {
    */
   public static Filter getVisibilityFilter(Transaction tx, Map<byte[], Long> ttlByFamily, boolean allowEmptyValues,
                                            ScanType scanType) {
-    return new CellSkipFilter(new TransactionVisibilityFilter(tx, ttlByFamily, allowEmptyValues, scanType, null));
+    return new CellSkipFilter(new TransactionVisibilityFilter(tx, ttlByFamily, allowEmptyValues, false,
+                                                              scanType, null));
   }
 
   /**
@@ -50,13 +51,15 @@ public class TransactionFilters {
    * @param ttlByFamily map of time-to-live (TTL) (in milliseconds) by column family name
    * @param allowEmptyValues if {@code true} cells with empty {@code byte[]} values will be returned, if {@code false}
    *                         these will be interpreted as "delete" markers and the column will be filtered out
+   * @param readNonTxnData whether data written before Tephra was enabled on a table should be readable
    * @param scanType the type of scan operation being performed
    * @param cellFilter if non-null, this filter will be applied to all cells visible to the current transaction, by
    *                   calling {@link Filter#filterKeyValue(org.apache.hadoop.hbase.Cell)}.  If null, then
    *                   {@link Filter.ReturnCode#INCLUDE_AND_NEXT_COL} will be returned instead.
    */
   public static Filter getVisibilityFilter(Transaction tx, Map<byte[], Long> ttlByFamily, boolean allowEmptyValues,
-                                           ScanType scanType, @Nullable Filter cellFilter) {
-    return new CellSkipFilter(new TransactionVisibilityFilter(tx, ttlByFamily, allowEmptyValues, scanType, cellFilter));
+                                           boolean readNonTxnData, ScanType scanType, @Nullable Filter cellFilter) {
+    return new CellSkipFilter(new TransactionVisibilityFilter(tx, ttlByFamily, allowEmptyValues, readNonTxnData,
+                                                              scanType, cellFilter));
   }
 }

--- a/tephra-hbase-compat-0.96/src/main/java/org/apache/tephra/hbase/coprocessor/TransactionProcessor.java
+++ b/tephra-hbase-compat-0.96/src/main/java/org/apache/tephra/hbase/coprocessor/TransactionProcessor.java
@@ -446,7 +446,7 @@ public class TransactionProcessor extends BaseRegionObserver {
    * @param type the type of scan operation being performed
    */
   protected Filter getTransactionFilter(Transaction tx, ScanType type, Filter filter) {
-    return TransactionFilters.getVisibilityFilter(tx, ttlByFamily, allowEmptyValues, type, filter);
+    return TransactionFilters.getVisibilityFilter(tx, ttlByFamily, allowEmptyValues, readNonTxnData, type, filter);
   }
 
   /**

--- a/tephra-hbase-compat-0.96/src/main/java/org/apache/tephra/hbase/coprocessor/TransactionVisibilityFilter.java
+++ b/tephra-hbase-compat-0.96/src/main/java/org/apache/tephra/hbase/coprocessor/TransactionVisibilityFilter.java
@@ -70,7 +70,7 @@ public class TransactionVisibilityFilter extends FilterBase {
    */
   public TransactionVisibilityFilter(Transaction tx, Map<byte[], Long> ttlByFamily, boolean allowEmptyValues,
                                      ScanType scanType) {
-    this(tx, ttlByFamily, allowEmptyValues, scanType, null);
+    this(tx, ttlByFamily, allowEmptyValues, false, scanType, null);
   }
 
   /**
@@ -80,19 +80,20 @@ public class TransactionVisibilityFilter extends FilterBase {
    * @param ttlByFamily map of time-to-live (TTL) (in milliseconds) by column family name
    * @param allowEmptyValues if {@code true} cells with empty {@code byte[]} values will be returned, if {@code false}
    *                         these will be interpreted as "delete" markers and the column will be filtered out
+   * @param readNonTxnData whether data written before Tephra was enabled on a table should be readable
    * @param scanType the type of scan operation being performed
    * @param cellFilter if non-null, this filter will be applied to all cells visible to the current transaction, by
    *                   calling {@link Filter#filterKeyValue(org.apache.hadoop.hbase.Cell)}.  If null, then
    *                   {@link Filter.ReturnCode#INCLUDE_AND_NEXT_COL} will be returned instead.
    */
-   public TransactionVisibilityFilter(Transaction tx, Map<byte[], Long> ttlByFamily, boolean allowEmptyValues,
-                               ScanType scanType, @Nullable Filter cellFilter) {
+  public TransactionVisibilityFilter(Transaction tx, Map<byte[], Long> ttlByFamily, boolean allowEmptyValues,
+                                     boolean readNonTxnData, ScanType scanType, @Nullable Filter cellFilter) {
     this.tx = tx;
     this.oldestTsByFamily = Maps.newTreeMap(Bytes.BYTES_COMPARATOR);
     for (Map.Entry<byte[], Long> ttlEntry : ttlByFamily.entrySet()) {
       long familyTTL = ttlEntry.getValue();
       oldestTsByFamily.put(ttlEntry.getKey(),
-                           familyTTL <= 0 ? 0 : tx.getVisibilityUpperBound() - familyTTL * TxConstants.MAX_TX_PER_MS);
+                           TxUtils.getOldestVisibleTimestamp(familyTTL, tx, readNonTxnData));
     }
     this.allowEmptyValues = allowEmptyValues;
     this.clearDeletes =

--- a/tephra-hbase-compat-0.96/src/test/java/org/apache/tephra/hbase/coprocessor/TransactionVisibilityFilterTest.java
+++ b/tephra-hbase-compat-0.96/src/test/java/org/apache/tephra/hbase/coprocessor/TransactionVisibilityFilterTest.java
@@ -74,7 +74,7 @@ public class TransactionVisibilityFilterTest extends AbstractTransactionVisibili
     TxFilterFactory txFilterFactory = new TxFilterFactory() {
       @Override
       public Filter getTxFilter(Transaction tx, Map<byte[], Long> familyTTLs) {
-        return new TransactionVisibilityFilter(tx, familyTTLs, false, ScanType.USER_SCAN, includeFilter);
+        return new TransactionVisibilityFilter(tx, familyTTLs, false, false, ScanType.USER_SCAN, includeFilter);
       }
     };
     runFilteringTest(txFilterFactory,
@@ -94,7 +94,7 @@ public class TransactionVisibilityFilterTest extends AbstractTransactionVisibili
     txFilterFactory = new TxFilterFactory() {
       @Override
       public Filter getTxFilter(Transaction tx, Map<byte[], Long> familyTTLs) {
-        return new TransactionVisibilityFilter(tx, familyTTLs, false, ScanType.USER_SCAN, skipFilter);
+        return new TransactionVisibilityFilter(tx, familyTTLs, false, false, ScanType.USER_SCAN, skipFilter);
       }
     };
     runFilteringTest(txFilterFactory,
@@ -114,7 +114,7 @@ public class TransactionVisibilityFilterTest extends AbstractTransactionVisibili
     txFilterFactory = new TxFilterFactory() {
       @Override
       public Filter getTxFilter(Transaction tx, Map<byte[], Long> familyTTLs) {
-        return new TransactionVisibilityFilter(tx, familyTTLs, false, ScanType.USER_SCAN, includeNextFilter);
+        return new TransactionVisibilityFilter(tx, familyTTLs, false, false, ScanType.USER_SCAN, includeNextFilter);
       }
     };
     runFilteringTest(txFilterFactory,
@@ -134,7 +134,7 @@ public class TransactionVisibilityFilterTest extends AbstractTransactionVisibili
     txFilterFactory = new TxFilterFactory() {
       @Override
       public Filter getTxFilter(Transaction tx, Map<byte[], Long> familyTTLs) {
-        return new TransactionVisibilityFilter(tx, familyTTLs, false, ScanType.USER_SCAN, nextColFilter);
+        return new TransactionVisibilityFilter(tx, familyTTLs, false, false, ScanType.USER_SCAN, nextColFilter);
       }
     };
     runFilteringTest(txFilterFactory,
@@ -294,8 +294,9 @@ public class TransactionVisibilityFilterTest extends AbstractTransactionVisibili
     ttls.put(FAM2, 30L);
     ttls.put(FAM3, 0L);
 
-    Transaction tx = txManager.startShort();
-    long now = tx.getVisibilityUpperBound();
+    long now = System.currentTimeMillis() * TxConstants.MAX_TX_PER_MS;
+    // we explicitly set the readPointer to 'now', because if you set it to an older value, it can filter values out
+    Transaction tx = new Transaction(now, now, new long[0], new long[0], now);
     Filter filter = new TransactionVisibilityFilter(tx, ttls, false, ScanType.USER_SCAN);
     assertEquals(Filter.ReturnCode.INCLUDE_AND_NEXT_COL,
                  filter.filterKeyValue(newKeyValue("row1", FAM, "val1", now)));
@@ -353,7 +354,7 @@ public class TransactionVisibilityFilterTest extends AbstractTransactionVisibili
   private class CustomTxFilter extends TransactionVisibilityFilter {
     public CustomTxFilter(Transaction tx, Map<byte[], Long> ttlByFamily, boolean allowEmptyValues, ScanType scanType,
                           @Nullable Filter cellFilter) {
-      super(tx, ttlByFamily, allowEmptyValues, scanType, cellFilter);
+      super(tx, ttlByFamily, allowEmptyValues, false, scanType, cellFilter);
     }
 
     @Override

--- a/tephra-hbase-compat-0.98/src/main/java/org/apache/tephra/hbase/coprocessor/TransactionFilters.java
+++ b/tephra-hbase-compat-0.98/src/main/java/org/apache/tephra/hbase/coprocessor/TransactionFilters.java
@@ -40,7 +40,8 @@ public class TransactionFilters {
    */
   public static Filter getVisibilityFilter(Transaction tx, Map<byte[], Long> ttlByFamily, boolean allowEmptyValues,
                                            ScanType scanType) {
-    return new CellSkipFilter(new TransactionVisibilityFilter(tx, ttlByFamily, allowEmptyValues, scanType, null));
+    return new CellSkipFilter(new TransactionVisibilityFilter(tx, ttlByFamily, allowEmptyValues, false,
+                                                              scanType, null));
   }
 
   /**
@@ -50,13 +51,15 @@ public class TransactionFilters {
    * @param ttlByFamily map of time-to-live (TTL) (in milliseconds) by column family name
    * @param allowEmptyValues if {@code true} cells with empty {@code byte[]} values will be returned, if {@code false}
    *                         these will be interpreted as "delete" markers and the column will be filtered out
+   * @param readNonTxnData whether data written before Tephra was enabled on a table should be readable
    * @param scanType the type of scan operation being performed
    * @param cellFilter if non-null, this filter will be applied to all cells visible to the current transaction, by
    *                   calling {@link Filter#filterKeyValue(org.apache.hadoop.hbase.Cell)}.  If null, then
    *                   {@link Filter.ReturnCode#INCLUDE_AND_NEXT_COL} will be returned instead.
    */
   public static Filter getVisibilityFilter(Transaction tx, Map<byte[], Long> ttlByFamily, boolean allowEmptyValues,
-                                           ScanType scanType, @Nullable Filter cellFilter) {
-    return new CellSkipFilter(new TransactionVisibilityFilter(tx, ttlByFamily, allowEmptyValues, scanType, cellFilter));
+                                           boolean readNonTxnData, ScanType scanType, @Nullable Filter cellFilter) {
+    return new CellSkipFilter(new TransactionVisibilityFilter(tx, ttlByFamily, allowEmptyValues, readNonTxnData,
+                                                              scanType, cellFilter));
   }
 }

--- a/tephra-hbase-compat-0.98/src/main/java/org/apache/tephra/hbase/coprocessor/TransactionProcessor.java
+++ b/tephra-hbase-compat-0.98/src/main/java/org/apache/tephra/hbase/coprocessor/TransactionProcessor.java
@@ -446,7 +446,7 @@ public class TransactionProcessor extends BaseRegionObserver {
    * @param type the type of scan being performed
    */
   protected Filter getTransactionFilter(Transaction tx, ScanType type, Filter filter) {
-    return TransactionFilters.getVisibilityFilter(tx, ttlByFamily, allowEmptyValues, type, filter);
+    return TransactionFilters.getVisibilityFilter(tx, ttlByFamily, allowEmptyValues, readNonTxnData, type, filter);
   }
 
   /**

--- a/tephra-hbase-compat-0.98/src/main/java/org/apache/tephra/hbase/coprocessor/TransactionVisibilityFilter.java
+++ b/tephra-hbase-compat-0.98/src/main/java/org/apache/tephra/hbase/coprocessor/TransactionVisibilityFilter.java
@@ -70,7 +70,7 @@ public class TransactionVisibilityFilter extends FilterBase {
    */
   public TransactionVisibilityFilter(Transaction tx, Map<byte[], Long> ttlByFamily, boolean allowEmptyValues,
                                      ScanType scanType) {
-    this(tx, ttlByFamily, allowEmptyValues, scanType, null);
+    this(tx, ttlByFamily, allowEmptyValues, false, scanType, null);
   }
 
   /**
@@ -80,19 +80,20 @@ public class TransactionVisibilityFilter extends FilterBase {
    * @param ttlByFamily map of time-to-live (TTL) (in milliseconds) by column family name
    * @param allowEmptyValues if {@code true} cells with empty {@code byte[]} values will be returned, if {@code false}
    *                         these will be interpreted as "delete" markers and the column will be filtered out
+   * @param readNonTxnData whether data written before Tephra was enabled on a table should be readable
    * @param scanType the type of scan operation being performed
    * @param cellFilter if non-null, this filter will be applied to all cells visible to the current transaction, by
    *                   calling {@link Filter#filterKeyValue(org.apache.hadoop.hbase.Cell)}.  If null, then
    *                   {@link Filter.ReturnCode#INCLUDE_AND_NEXT_COL} will be returned instead.
    */
   public TransactionVisibilityFilter(Transaction tx, Map<byte[], Long> ttlByFamily, boolean allowEmptyValues,
-                              ScanType scanType, @Nullable Filter cellFilter) {
+                                     boolean readNonTxnData, ScanType scanType, @Nullable Filter cellFilter) {
     this.tx = tx;
     this.oldestTsByFamily = Maps.newTreeMap(Bytes.BYTES_COMPARATOR);
     for (Map.Entry<byte[], Long> ttlEntry : ttlByFamily.entrySet()) {
       long familyTTL = ttlEntry.getValue();
       oldestTsByFamily.put(ttlEntry.getKey(),
-                           familyTTL <= 0 ? 0 : tx.getVisibilityUpperBound() - familyTTL * TxConstants.MAX_TX_PER_MS);
+                           TxUtils.getOldestVisibleTimestamp(familyTTL, tx, readNonTxnData));
     }
     this.allowEmptyValues = allowEmptyValues;
     this.clearDeletes =

--- a/tephra-hbase-compat-0.98/src/test/java/org/apache/tephra/hbase/coprocessor/TransactionVisibilityFilterTest.java
+++ b/tephra-hbase-compat-0.98/src/test/java/org/apache/tephra/hbase/coprocessor/TransactionVisibilityFilterTest.java
@@ -74,7 +74,7 @@ public class TransactionVisibilityFilterTest extends AbstractTransactionVisibili
     TxFilterFactory txFilterFactory = new TxFilterFactory() {
       @Override
       public Filter getTxFilter(Transaction tx, Map<byte[], Long> familyTTLs) {
-        return new TransactionVisibilityFilter(tx, familyTTLs, false, ScanType.USER_SCAN, includeFilter);
+        return new TransactionVisibilityFilter(tx, familyTTLs, false, false, ScanType.USER_SCAN, includeFilter);
       }
     };
     runFilteringTest(txFilterFactory,
@@ -94,7 +94,7 @@ public class TransactionVisibilityFilterTest extends AbstractTransactionVisibili
     txFilterFactory = new TxFilterFactory() {
       @Override
       public Filter getTxFilter(Transaction tx, Map<byte[], Long> familyTTLs) {
-        return new TransactionVisibilityFilter(tx, familyTTLs, false, ScanType.USER_SCAN, skipFilter);
+        return new TransactionVisibilityFilter(tx, familyTTLs, false, false, ScanType.USER_SCAN, skipFilter);
       }
     };
     runFilteringTest(txFilterFactory,
@@ -114,7 +114,7 @@ public class TransactionVisibilityFilterTest extends AbstractTransactionVisibili
     txFilterFactory = new TxFilterFactory() {
       @Override
       public Filter getTxFilter(Transaction tx, Map<byte[], Long> familyTTLs) {
-        return new TransactionVisibilityFilter(tx, familyTTLs, false, ScanType.USER_SCAN, includeNextFilter);
+        return new TransactionVisibilityFilter(tx, familyTTLs, false, false, ScanType.USER_SCAN, includeNextFilter);
       }
     };
     runFilteringTest(txFilterFactory,
@@ -134,7 +134,7 @@ public class TransactionVisibilityFilterTest extends AbstractTransactionVisibili
     txFilterFactory = new TxFilterFactory() {
       @Override
       public Filter getTxFilter(Transaction tx, Map<byte[], Long> familyTTLs) {
-        return new TransactionVisibilityFilter(tx, familyTTLs, false, ScanType.USER_SCAN, nextColFilter);
+        return new TransactionVisibilityFilter(tx, familyTTLs, false, false, ScanType.USER_SCAN, nextColFilter);
       }
     };
     runFilteringTest(txFilterFactory,
@@ -293,8 +293,9 @@ public class TransactionVisibilityFilterTest extends AbstractTransactionVisibili
     ttls.put(FAM2, 30L);
     ttls.put(FAM3, 0L);
 
-    Transaction tx = txManager.startShort();
-    long now = tx.getVisibilityUpperBound();
+    long now = System.currentTimeMillis() * TxConstants.MAX_TX_PER_MS;
+    // we explicitly set the readPointer to 'now', because if you set it to an older value, it can filter values out
+    Transaction tx = new Transaction(now, now, new long[0], new long[0], now);
     Filter filter = new TransactionVisibilityFilter(tx, ttls, false, ScanType.USER_SCAN);
     assertEquals(Filter.ReturnCode.INCLUDE_AND_NEXT_COL,
                  filter.filterKeyValue(newKeyValue("row1", FAM, "val1", now)));
@@ -352,7 +353,7 @@ public class TransactionVisibilityFilterTest extends AbstractTransactionVisibili
   private class CustomTxFilter extends TransactionVisibilityFilter {
     public CustomTxFilter(Transaction tx, Map<byte[], Long> ttlByFamily, boolean allowEmptyValues, ScanType scanType,
                           @Nullable Filter cellFilter) {
-      super(tx, ttlByFamily, allowEmptyValues, scanType, cellFilter);
+      super(tx, ttlByFamily, allowEmptyValues, false, scanType, cellFilter);
     }
 
     @Override

--- a/tephra-hbase-compat-1.0-cdh/src/main/java/org/apache/tephra/hbase/coprocessor/TransactionFilters.java
+++ b/tephra-hbase-compat-1.0-cdh/src/main/java/org/apache/tephra/hbase/coprocessor/TransactionFilters.java
@@ -40,7 +40,8 @@ public class TransactionFilters {
    */
   public static Filter getVisibilityFilter(Transaction tx, Map<byte[], Long> ttlByFamily, boolean allowEmptyValues,
                                            ScanType scanType) {
-    return new CellSkipFilter(new TransactionVisibilityFilter(tx, ttlByFamily, allowEmptyValues, scanType, null));
+    return new CellSkipFilter(new TransactionVisibilityFilter(tx, ttlByFamily, allowEmptyValues, false,
+                                                              scanType, null));
   }
 
   /**
@@ -50,13 +51,15 @@ public class TransactionFilters {
    * @param ttlByFamily map of time-to-live (TTL) (in milliseconds) by column family name
    * @param allowEmptyValues if {@code true} cells with empty {@code byte[]} values will be returned, if {@code false}
    *                         these will be interpreted as "delete" markers and the column will be filtered out
+   * @param readNonTxnData whether data written before Tephra was enabled on a table should be readable
    * @param scanType the type of scan operation being performed
    * @param cellFilter if non-null, this filter will be applied to all cells visible to the current transaction, by
    *                   calling {@link Filter#filterKeyValue(org.apache.hadoop.hbase.Cell)}.  If null, then
    *                   {@link Filter.ReturnCode#INCLUDE_AND_NEXT_COL} will be returned instead.
    */
   public static Filter getVisibilityFilter(Transaction tx, Map<byte[], Long> ttlByFamily, boolean allowEmptyValues,
-                                           ScanType scanType, @Nullable Filter cellFilter) {
-    return new CellSkipFilter(new TransactionVisibilityFilter(tx, ttlByFamily, allowEmptyValues, scanType, cellFilter));
+                                           boolean readNonTxnData, ScanType scanType, @Nullable Filter cellFilter) {
+    return new CellSkipFilter(new TransactionVisibilityFilter(tx, ttlByFamily, allowEmptyValues, readNonTxnData,
+                                                              scanType, cellFilter));
   }
 }

--- a/tephra-hbase-compat-1.0-cdh/src/main/java/org/apache/tephra/hbase/coprocessor/TransactionProcessor.java
+++ b/tephra-hbase-compat-1.0-cdh/src/main/java/org/apache/tephra/hbase/coprocessor/TransactionProcessor.java
@@ -446,7 +446,7 @@ public class TransactionProcessor extends BaseRegionObserver {
    * @param type the type of scan being performed
    */
   protected Filter getTransactionFilter(Transaction tx, ScanType type, Filter filter) {
-    return TransactionFilters.getVisibilityFilter(tx, ttlByFamily, allowEmptyValues, type, filter);
+    return TransactionFilters.getVisibilityFilter(tx, ttlByFamily, allowEmptyValues, readNonTxnData, type, filter);
   }
 
   /**

--- a/tephra-hbase-compat-1.0-cdh/src/main/java/org/apache/tephra/hbase/coprocessor/TransactionVisibilityFilter.java
+++ b/tephra-hbase-compat-1.0-cdh/src/main/java/org/apache/tephra/hbase/coprocessor/TransactionVisibilityFilter.java
@@ -73,7 +73,7 @@ public class TransactionVisibilityFilter extends FilterBase {
    */
   public TransactionVisibilityFilter(Transaction tx, Map<byte[], Long> ttlByFamily, boolean allowEmptyValues,
                                      ScanType scanType) {
-    this(tx, ttlByFamily, allowEmptyValues, scanType, null);
+    this(tx, ttlByFamily, allowEmptyValues, false, scanType, null);
   }
 
   /**
@@ -83,19 +83,20 @@ public class TransactionVisibilityFilter extends FilterBase {
    * @param ttlByFamily map of time-to-live (TTL) (in milliseconds) by column family name
    * @param allowEmptyValues if {@code true} cells with empty {@code byte[]} values will be returned, if {@code false}
    *                         these will be interpreted as "delete" markers and the column will be filtered out
+   * @param readNonTxnData whether data written before Tephra was enabled on a table should be readable
    * @param scanType the type of scan operation being performed
    * @param cellFilter if non-null, this filter will be applied to all cells visible to the current transaction, by
    *                   calling {@link Filter#filterKeyValue(org.apache.hadoop.hbase.Cell)}.  If null, then
    *                   {@link Filter.ReturnCode#INCLUDE_AND_NEXT_COL} will be returned instead.
    */
   public TransactionVisibilityFilter(Transaction tx, Map<byte[], Long> ttlByFamily, boolean allowEmptyValues,
-                              ScanType scanType, @Nullable Filter cellFilter) {
+                                     boolean readNonTxnData, ScanType scanType, @Nullable Filter cellFilter) {
     this.tx = tx;
     this.oldestTsByFamily = Maps.newTreeMap();
     for (Map.Entry<byte[], Long> ttlEntry : ttlByFamily.entrySet()) {
       long familyTTL = ttlEntry.getValue();
       oldestTsByFamily.put(new ImmutableBytesWritable(ttlEntry.getKey()),
-                           familyTTL <= 0 ? 0 : tx.getVisibilityUpperBound() - familyTTL * TxConstants.MAX_TX_PER_MS);
+                           TxUtils.getOldestVisibleTimestamp(familyTTL, tx, readNonTxnData));
     }
     this.allowEmptyValues = allowEmptyValues;
     this.clearDeletes =

--- a/tephra-hbase-compat-1.0-cdh/src/test/java/org/apache/tephra/hbase/coprocessor/TransactionVisibilityFilterTest.java
+++ b/tephra-hbase-compat-1.0-cdh/src/test/java/org/apache/tephra/hbase/coprocessor/TransactionVisibilityFilterTest.java
@@ -74,7 +74,7 @@ public class TransactionVisibilityFilterTest extends AbstractTransactionVisibili
     TxFilterFactory txFilterFactory = new TxFilterFactory() {
       @Override
       public Filter getTxFilter(Transaction tx, Map<byte[], Long> familyTTLs) {
-        return new TransactionVisibilityFilter(tx, familyTTLs, false, ScanType.USER_SCAN, includeFilter);
+        return new TransactionVisibilityFilter(tx, familyTTLs, false, false, ScanType.USER_SCAN, includeFilter);
       }
     };
     runFilteringTest(txFilterFactory,
@@ -94,7 +94,7 @@ public class TransactionVisibilityFilterTest extends AbstractTransactionVisibili
     txFilterFactory = new TxFilterFactory() {
       @Override
       public Filter getTxFilter(Transaction tx, Map<byte[], Long> familyTTLs) {
-        return new TransactionVisibilityFilter(tx, familyTTLs, false, ScanType.USER_SCAN, skipFilter);
+        return new TransactionVisibilityFilter(tx, familyTTLs, false, false, ScanType.USER_SCAN, skipFilter);
       }
     };
     runFilteringTest(txFilterFactory,
@@ -114,7 +114,7 @@ public class TransactionVisibilityFilterTest extends AbstractTransactionVisibili
     txFilterFactory = new TxFilterFactory() {
       @Override
       public Filter getTxFilter(Transaction tx, Map<byte[], Long> familyTTLs) {
-        return new TransactionVisibilityFilter(tx, familyTTLs, false, ScanType.USER_SCAN, includeNextFilter);
+        return new TransactionVisibilityFilter(tx, familyTTLs, false, false, ScanType.USER_SCAN, includeNextFilter);
       }
     };
     runFilteringTest(txFilterFactory,
@@ -134,7 +134,7 @@ public class TransactionVisibilityFilterTest extends AbstractTransactionVisibili
     txFilterFactory = new TxFilterFactory() {
       @Override
       public Filter getTxFilter(Transaction tx, Map<byte[], Long> familyTTLs) {
-        return new TransactionVisibilityFilter(tx, familyTTLs, false, ScanType.USER_SCAN, nextColFilter);
+        return new TransactionVisibilityFilter(tx, familyTTLs, false, false, ScanType.USER_SCAN, nextColFilter);
       }
     };
     runFilteringTest(txFilterFactory,
@@ -293,8 +293,9 @@ public class TransactionVisibilityFilterTest extends AbstractTransactionVisibili
     ttls.put(FAM2, 30L);
     ttls.put(FAM3, 0L);
 
-    Transaction tx = txManager.startShort();
-    long now = tx.getVisibilityUpperBound();
+    long now = System.currentTimeMillis() * TxConstants.MAX_TX_PER_MS;
+    // we explicitly set the readPointer to 'now', because if you set it to an older value, it can filter values out
+    Transaction tx = new Transaction(now, now, new long[0], new long[0], now);
     Filter filter = new TransactionVisibilityFilter(tx, ttls, false, ScanType.USER_SCAN);
     assertEquals(Filter.ReturnCode.INCLUDE_AND_NEXT_COL,
                  filter.filterKeyValue(newKeyValue("row1", FAM, "val1", now)));
@@ -352,7 +353,7 @@ public class TransactionVisibilityFilterTest extends AbstractTransactionVisibili
   private class CustomTxFilter extends TransactionVisibilityFilter {
     public CustomTxFilter(Transaction tx, Map<byte[], Long> ttlByFamily, boolean allowEmptyValues, ScanType scanType,
                           @Nullable Filter cellFilter) {
-      super(tx, ttlByFamily, allowEmptyValues, scanType, cellFilter);
+      super(tx, ttlByFamily, allowEmptyValues, false, scanType, cellFilter);
     }
 
     @Override

--- a/tephra-hbase-compat-1.0/src/main/java/org/apache/tephra/hbase/coprocessor/TransactionFilters.java
+++ b/tephra-hbase-compat-1.0/src/main/java/org/apache/tephra/hbase/coprocessor/TransactionFilters.java
@@ -40,7 +40,8 @@ public class TransactionFilters {
    */
   public static Filter getVisibilityFilter(Transaction tx, Map<byte[], Long> ttlByFamily, boolean allowEmptyValues,
                                            ScanType scanType) {
-    return new CellSkipFilter(new TransactionVisibilityFilter(tx, ttlByFamily, allowEmptyValues, scanType, null));
+    return new CellSkipFilter(new TransactionVisibilityFilter(tx, ttlByFamily, allowEmptyValues, false,
+                                                              scanType, null));
   }
 
   /**
@@ -50,13 +51,15 @@ public class TransactionFilters {
    * @param ttlByFamily map of time-to-live (TTL) (in milliseconds) by column family name
    * @param allowEmptyValues if {@code true} cells with empty {@code byte[]} values will be returned, if {@code false}
    *                         these will be interpreted as "delete" markers and the column will be filtered out
+   * @param readNonTxnData whether data written before Tephra was enabled on a table should be readable
    * @param scanType the type of scan operation being performed
    * @param cellFilter if non-null, this filter will be applied to all cells visible to the current transaction, by
    *                   calling {@link Filter#filterKeyValue(org.apache.hadoop.hbase.Cell)}.  If null, then
    *                   {@link Filter.ReturnCode#INCLUDE_AND_NEXT_COL} will be returned instead.
    */
   public static Filter getVisibilityFilter(Transaction tx, Map<byte[], Long> ttlByFamily, boolean allowEmptyValues,
-                                           ScanType scanType, @Nullable Filter cellFilter) {
-    return new CellSkipFilter(new TransactionVisibilityFilter(tx, ttlByFamily, allowEmptyValues, scanType, cellFilter));
+                                           boolean readNonTxnData, ScanType scanType, @Nullable Filter cellFilter) {
+    return new CellSkipFilter(new TransactionVisibilityFilter(tx, ttlByFamily, allowEmptyValues, readNonTxnData,
+                                                              scanType, cellFilter));
   }
 }

--- a/tephra-hbase-compat-1.0/src/main/java/org/apache/tephra/hbase/coprocessor/TransactionProcessor.java
+++ b/tephra-hbase-compat-1.0/src/main/java/org/apache/tephra/hbase/coprocessor/TransactionProcessor.java
@@ -446,7 +446,7 @@ public class TransactionProcessor extends BaseRegionObserver {
    * @param type the type of scan being performed
    */
   protected Filter getTransactionFilter(Transaction tx, ScanType type, Filter filter) {
-    return TransactionFilters.getVisibilityFilter(tx, ttlByFamily, allowEmptyValues, type, filter);
+    return TransactionFilters.getVisibilityFilter(tx, ttlByFamily, allowEmptyValues, readNonTxnData, type, filter);
   }
 
   /**

--- a/tephra-hbase-compat-1.0/src/main/java/org/apache/tephra/hbase/coprocessor/TransactionVisibilityFilter.java
+++ b/tephra-hbase-compat-1.0/src/main/java/org/apache/tephra/hbase/coprocessor/TransactionVisibilityFilter.java
@@ -73,7 +73,7 @@ public class TransactionVisibilityFilter extends FilterBase {
    */
   public TransactionVisibilityFilter(Transaction tx, Map<byte[], Long> ttlByFamily, boolean allowEmptyValues,
                                      ScanType scanType) {
-    this(tx, ttlByFamily, allowEmptyValues, scanType, null);
+    this(tx, ttlByFamily, allowEmptyValues, false, scanType, null);
   }
 
   /**
@@ -83,19 +83,20 @@ public class TransactionVisibilityFilter extends FilterBase {
    * @param ttlByFamily map of time-to-live (TTL) (in milliseconds) by column family name
    * @param allowEmptyValues if {@code true} cells with empty {@code byte[]} values will be returned, if {@code false}
    *                         these will be interpreted as "delete" markers and the column will be filtered out
+   * @param readNonTxnData whether data written before Tephra was enabled on a table should be readable
    * @param scanType the type of scan operation being performed
    * @param cellFilter if non-null, this filter will be applied to all cells visible to the current transaction, by
    *                   calling {@link Filter#filterKeyValue(org.apache.hadoop.hbase.Cell)}.  If null, then
    *                   {@link Filter.ReturnCode#INCLUDE_AND_NEXT_COL} will be returned instead.
    */
   public TransactionVisibilityFilter(Transaction tx, Map<byte[], Long> ttlByFamily, boolean allowEmptyValues,
-                              ScanType scanType, @Nullable Filter cellFilter) {
+                                     boolean readNonTxnData, ScanType scanType, @Nullable Filter cellFilter) {
     this.tx = tx;
     this.oldestTsByFamily = Maps.newTreeMap();
     for (Map.Entry<byte[], Long> ttlEntry : ttlByFamily.entrySet()) {
       long familyTTL = ttlEntry.getValue();
       oldestTsByFamily.put(new ImmutableBytesWritable(ttlEntry.getKey()),
-                           familyTTL <= 0 ? 0 : tx.getVisibilityUpperBound() - familyTTL * TxConstants.MAX_TX_PER_MS);
+                           TxUtils.getOldestVisibleTimestamp(familyTTL, tx, readNonTxnData));
     }
     this.allowEmptyValues = allowEmptyValues;
     this.clearDeletes =

--- a/tephra-hbase-compat-1.0/src/test/java/org/apache/tephra/hbase/coprocessor/TransactionVisibilityFilterTest.java
+++ b/tephra-hbase-compat-1.0/src/test/java/org/apache/tephra/hbase/coprocessor/TransactionVisibilityFilterTest.java
@@ -74,7 +74,7 @@ public class TransactionVisibilityFilterTest extends AbstractTransactionVisibili
     TxFilterFactory txFilterFactory = new TxFilterFactory() {
       @Override
       public Filter getTxFilter(Transaction tx, Map<byte[], Long> familyTTLs) {
-        return new TransactionVisibilityFilter(tx, familyTTLs, false, ScanType.USER_SCAN, includeFilter);
+        return new TransactionVisibilityFilter(tx, familyTTLs, false, false, ScanType.USER_SCAN, includeFilter);
       }
     };
     runFilteringTest(txFilterFactory,
@@ -94,7 +94,7 @@ public class TransactionVisibilityFilterTest extends AbstractTransactionVisibili
     txFilterFactory = new TxFilterFactory() {
       @Override
       public Filter getTxFilter(Transaction tx, Map<byte[], Long> familyTTLs) {
-        return new TransactionVisibilityFilter(tx, familyTTLs, false, ScanType.USER_SCAN, skipFilter);
+        return new TransactionVisibilityFilter(tx, familyTTLs, false, false, ScanType.USER_SCAN, skipFilter);
       }
     };
     runFilteringTest(txFilterFactory,
@@ -114,7 +114,7 @@ public class TransactionVisibilityFilterTest extends AbstractTransactionVisibili
     txFilterFactory = new TxFilterFactory() {
       @Override
       public Filter getTxFilter(Transaction tx, Map<byte[], Long> familyTTLs) {
-        return new TransactionVisibilityFilter(tx, familyTTLs, false, ScanType.USER_SCAN, includeNextFilter);
+        return new TransactionVisibilityFilter(tx, familyTTLs, false, false, ScanType.USER_SCAN, includeNextFilter);
       }
     };
     runFilteringTest(txFilterFactory,
@@ -134,7 +134,7 @@ public class TransactionVisibilityFilterTest extends AbstractTransactionVisibili
     txFilterFactory = new TxFilterFactory() {
       @Override
       public Filter getTxFilter(Transaction tx, Map<byte[], Long> familyTTLs) {
-        return new TransactionVisibilityFilter(tx, familyTTLs, false, ScanType.USER_SCAN, nextColFilter);
+        return new TransactionVisibilityFilter(tx, familyTTLs, false, false, ScanType.USER_SCAN, nextColFilter);
       }
     };
     runFilteringTest(txFilterFactory,
@@ -293,8 +293,9 @@ public class TransactionVisibilityFilterTest extends AbstractTransactionVisibili
     ttls.put(FAM2, 30L);
     ttls.put(FAM3, 0L);
 
-    Transaction tx = txManager.startShort();
-    long now = tx.getVisibilityUpperBound();
+    long now = System.currentTimeMillis() * TxConstants.MAX_TX_PER_MS;
+    // we explicitly set the readPointer to 'now', because if you set it to an older value, it can filter values out
+    Transaction tx = new Transaction(now, now, new long[0], new long[0], now);
     Filter filter = new TransactionVisibilityFilter(tx, ttls, false, ScanType.USER_SCAN);
     assertEquals(Filter.ReturnCode.INCLUDE_AND_NEXT_COL,
                  filter.filterKeyValue(newKeyValue("row1", FAM, "val1", now)));
@@ -352,7 +353,7 @@ public class TransactionVisibilityFilterTest extends AbstractTransactionVisibili
   private class CustomTxFilter extends TransactionVisibilityFilter {
     public CustomTxFilter(Transaction tx, Map<byte[], Long> ttlByFamily, boolean allowEmptyValues, ScanType scanType,
                           @Nullable Filter cellFilter) {
-      super(tx, ttlByFamily, allowEmptyValues, scanType, cellFilter);
+      super(tx, ttlByFamily, allowEmptyValues, false, scanType, cellFilter);
     }
 
     @Override

--- a/tephra-hbase-compat-1.1-base/src/main/java/org/apache/tephra/hbase/coprocessor/TransactionFilters.java
+++ b/tephra-hbase-compat-1.1-base/src/main/java/org/apache/tephra/hbase/coprocessor/TransactionFilters.java
@@ -40,7 +40,8 @@ public class TransactionFilters {
    */
   public static Filter getVisibilityFilter(Transaction tx, Map<byte[], Long> ttlByFamily, boolean allowEmptyValues,
                                            ScanType scanType) {
-    return new CellSkipFilter(new TransactionVisibilityFilter(tx, ttlByFamily, allowEmptyValues, scanType, null));
+    return new CellSkipFilter(new TransactionVisibilityFilter(tx, ttlByFamily, allowEmptyValues, false,
+                                                              scanType, null));
   }
 
   /**
@@ -50,13 +51,15 @@ public class TransactionFilters {
    * @param ttlByFamily map of time-to-live (TTL) (in milliseconds) by column family name
    * @param allowEmptyValues if {@code true} cells with empty {@code byte[]} values will be returned, if {@code false}
    *                         these will be interpreted as "delete" markers and the column will be filtered out
+   * @param readNonTxnData whether data written before Tephra was enabled on a table should be readable
    * @param scanType the type of scan operation being performed
    * @param cellFilter if non-null, this filter will be applied to all cells visible to the current transaction, by
    *                   calling {@link Filter#filterKeyValue(org.apache.hadoop.hbase.Cell)}.  If null, then
    *                   {@link Filter.ReturnCode#INCLUDE_AND_NEXT_COL} will be returned instead.
    */
   public static Filter getVisibilityFilter(Transaction tx, Map<byte[], Long> ttlByFamily, boolean allowEmptyValues,
-                                           ScanType scanType, @Nullable Filter cellFilter) {
-    return new CellSkipFilter(new TransactionVisibilityFilter(tx, ttlByFamily, allowEmptyValues, scanType, cellFilter));
+                                           boolean readNonTxnData, ScanType scanType, @Nullable Filter cellFilter) {
+    return new CellSkipFilter(new TransactionVisibilityFilter(tx, ttlByFamily, allowEmptyValues, readNonTxnData,
+                                                              scanType, cellFilter));
   }
 }

--- a/tephra-hbase-compat-1.1-base/src/main/java/org/apache/tephra/hbase/coprocessor/TransactionProcessor.java
+++ b/tephra-hbase-compat-1.1-base/src/main/java/org/apache/tephra/hbase/coprocessor/TransactionProcessor.java
@@ -446,7 +446,7 @@ public class TransactionProcessor extends BaseRegionObserver {
    * @param type the type of scan being performed
    */
   protected Filter getTransactionFilter(Transaction tx, ScanType type, Filter filter) {
-    return TransactionFilters.getVisibilityFilter(tx, ttlByFamily, allowEmptyValues, type, filter);
+    return TransactionFilters.getVisibilityFilter(tx, ttlByFamily, allowEmptyValues, readNonTxnData, type, filter);
   }
 
   /**

--- a/tephra-hbase-compat-1.1-base/src/main/java/org/apache/tephra/hbase/coprocessor/TransactionVisibilityFilter.java
+++ b/tephra-hbase-compat-1.1-base/src/main/java/org/apache/tephra/hbase/coprocessor/TransactionVisibilityFilter.java
@@ -70,8 +70,8 @@ public class TransactionVisibilityFilter extends FilterBase {
    * @param scanType the type of scan operation being performed
    */
   public TransactionVisibilityFilter(Transaction tx, Map<byte[], Long> ttlByFamily, boolean allowEmptyValues,
-                              ScanType scanType) {
-    this(tx, ttlByFamily, allowEmptyValues, scanType, null);
+                                     ScanType scanType) {
+    this(tx, ttlByFamily, allowEmptyValues, false, scanType, null);
   }
 
   /**
@@ -81,19 +81,20 @@ public class TransactionVisibilityFilter extends FilterBase {
    * @param ttlByFamily map of time-to-live (TTL) (in milliseconds) by column family name
    * @param allowEmptyValues if {@code true} cells with empty {@code byte[]} values will be returned, if {@code false}
    *                         these will be interpreted as "delete" markers and the column will be filtered out
+   * @param readNonTxnData whether data written before Tephra was enabled on a table should be readable
    * @param scanType the type of scan operation being performed
    * @param cellFilter if non-null, this filter will be applied to all cells visible to the current transaction, by
    *                   calling {@link Filter#filterKeyValue(org.apache.hadoop.hbase.Cell)}.  If null, then
    *                   {@link Filter.ReturnCode#INCLUDE_AND_NEXT_COL} will be returned instead.
    */
-   public TransactionVisibilityFilter(Transaction tx, Map<byte[], Long> ttlByFamily, boolean allowEmptyValues,
-                               ScanType scanType, @Nullable Filter cellFilter) {
+  public TransactionVisibilityFilter(Transaction tx, Map<byte[], Long> ttlByFamily, boolean allowEmptyValues,
+                                     boolean readNonTxnData, ScanType scanType, @Nullable Filter cellFilter) {
     this.tx = tx;
     this.oldestTsByFamily = Maps.newTreeMap();
     for (Map.Entry<byte[], Long> ttlEntry : ttlByFamily.entrySet()) {
       long familyTTL = ttlEntry.getValue();
       oldestTsByFamily.put(new ImmutableBytesWritable(ttlEntry.getKey()),
-                           familyTTL <= 0 ? 0 : tx.getVisibilityUpperBound() - familyTTL * TxConstants.MAX_TX_PER_MS);
+                           TxUtils.getOldestVisibleTimestamp(familyTTL, tx, readNonTxnData));
     }
     this.allowEmptyValues = allowEmptyValues;
     this.clearDeletes =

--- a/tephra-hbase-compat-1.1-base/src/test/java/org/apache/tephra/hbase/coprocessor/TransactionVisibilityFilterTest.java
+++ b/tephra-hbase-compat-1.1-base/src/test/java/org/apache/tephra/hbase/coprocessor/TransactionVisibilityFilterTest.java
@@ -74,7 +74,7 @@ public class TransactionVisibilityFilterTest extends AbstractTransactionVisibili
     TxFilterFactory txFilterFactory = new TxFilterFactory() {
       @Override
       public Filter getTxFilter(Transaction tx, Map<byte[], Long> familyTTLs) {
-        return new TransactionVisibilityFilter(tx, familyTTLs, false, ScanType.USER_SCAN, includeFilter);
+        return new TransactionVisibilityFilter(tx, familyTTLs, false, false, ScanType.USER_SCAN, includeFilter);
       }
     };
     runFilteringTest(txFilterFactory,
@@ -94,7 +94,7 @@ public class TransactionVisibilityFilterTest extends AbstractTransactionVisibili
     txFilterFactory = new TxFilterFactory() {
       @Override
       public Filter getTxFilter(Transaction tx, Map<byte[], Long> familyTTLs) {
-        return new TransactionVisibilityFilter(tx, familyTTLs, false, ScanType.USER_SCAN, skipFilter);
+        return new TransactionVisibilityFilter(tx, familyTTLs, false, false, ScanType.USER_SCAN, skipFilter);
       }
     };
     runFilteringTest(txFilterFactory,
@@ -114,7 +114,7 @@ public class TransactionVisibilityFilterTest extends AbstractTransactionVisibili
     txFilterFactory = new TxFilterFactory() {
       @Override
       public Filter getTxFilter(Transaction tx, Map<byte[], Long> familyTTLs) {
-        return new TransactionVisibilityFilter(tx, familyTTLs, false, ScanType.USER_SCAN, includeNextFilter);
+        return new TransactionVisibilityFilter(tx, familyTTLs, false, false, ScanType.USER_SCAN, includeNextFilter);
       }
     };
     runFilteringTest(txFilterFactory,
@@ -134,7 +134,7 @@ public class TransactionVisibilityFilterTest extends AbstractTransactionVisibili
     txFilterFactory = new TxFilterFactory() {
       @Override
       public Filter getTxFilter(Transaction tx, Map<byte[], Long> familyTTLs) {
-        return new TransactionVisibilityFilter(tx, familyTTLs, false, ScanType.USER_SCAN, nextColFilter);
+        return new TransactionVisibilityFilter(tx, familyTTLs, false, false, ScanType.USER_SCAN, nextColFilter);
       }
     };
     runFilteringTest(txFilterFactory,
@@ -294,8 +294,9 @@ public class TransactionVisibilityFilterTest extends AbstractTransactionVisibili
     ttls.put(FAM2, 30L);
     ttls.put(FAM3, 0L);
 
-    Transaction tx = txManager.startShort();
-    long now = tx.getVisibilityUpperBound();
+    long now = System.currentTimeMillis() * TxConstants.MAX_TX_PER_MS;
+    // we explicitly set the readPointer to 'now', because if you set it to an older value, it can filter values out
+    Transaction tx = new Transaction(now, now, new long[0], new long[0], now);
     Filter filter = new TransactionVisibilityFilter(tx, ttls, false, ScanType.USER_SCAN);
     assertEquals(Filter.ReturnCode.INCLUDE_AND_NEXT_COL,
                  filter.filterKeyValue(newKeyValue("row1", FAM, "val1", now)));
@@ -353,7 +354,7 @@ public class TransactionVisibilityFilterTest extends AbstractTransactionVisibili
   private class CustomTxFilter extends TransactionVisibilityFilter {
     public CustomTxFilter(Transaction tx, Map<byte[], Long> ttlByFamily, boolean allowEmptyValues, ScanType scanType,
                           @Nullable Filter cellFilter) {
-      super(tx, ttlByFamily, allowEmptyValues, scanType, cellFilter);
+      super(tx, ttlByFamily, allowEmptyValues, false, scanType, cellFilter);
     }
 
     @Override

--- a/tephra-hbase-compat-1.3/src/main/java/org/apache/tephra/hbase/coprocessor/TransactionFilters.java
+++ b/tephra-hbase-compat-1.3/src/main/java/org/apache/tephra/hbase/coprocessor/TransactionFilters.java
@@ -40,7 +40,8 @@ public class TransactionFilters {
    */
   public static Filter getVisibilityFilter(Transaction tx, Map<byte[], Long> ttlByFamily, boolean allowEmptyValues,
                                            ScanType scanType) {
-    return new CellSkipFilter(new TransactionVisibilityFilter(tx, ttlByFamily, allowEmptyValues, scanType, null));
+    return new CellSkipFilter(new TransactionVisibilityFilter(tx, ttlByFamily, allowEmptyValues, false,
+                                                              scanType, null));
   }
 
   /**
@@ -50,13 +51,15 @@ public class TransactionFilters {
    * @param ttlByFamily map of time-to-live (TTL) (in milliseconds) by column family name
    * @param allowEmptyValues if {@code true} cells with empty {@code byte[]} values will be returned, if {@code false}
    *                         these will be interpreted as "delete" markers and the column will be filtered out
+   * @param readNonTxnData whether data written before Tephra was enabled on a table should be readable
    * @param scanType the type of scan operation being performed
    * @param cellFilter if non-null, this filter will be applied to all cells visible to the current transaction, by
    *                   calling {@link Filter#filterKeyValue(org.apache.hadoop.hbase.Cell)}.  If null, then
    *                   {@link Filter.ReturnCode#INCLUDE_AND_NEXT_COL} will be returned instead.
    */
   public static Filter getVisibilityFilter(Transaction tx, Map<byte[], Long> ttlByFamily, boolean allowEmptyValues,
-                                           ScanType scanType, @Nullable Filter cellFilter) {
-    return new CellSkipFilter(new TransactionVisibilityFilter(tx, ttlByFamily, allowEmptyValues, scanType, cellFilter));
+                                           boolean readNonTxnData, ScanType scanType, @Nullable Filter cellFilter) {
+    return new CellSkipFilter(new TransactionVisibilityFilter(tx, ttlByFamily, allowEmptyValues, readNonTxnData,
+                                                              scanType, cellFilter));
   }
 }

--- a/tephra-hbase-compat-1.3/src/main/java/org/apache/tephra/hbase/coprocessor/TransactionProcessor.java
+++ b/tephra-hbase-compat-1.3/src/main/java/org/apache/tephra/hbase/coprocessor/TransactionProcessor.java
@@ -446,7 +446,7 @@ public class TransactionProcessor extends BaseRegionObserver {
    * @param type the type of scan being performed
    */
   protected Filter getTransactionFilter(Transaction tx, ScanType type, Filter filter) {
-    return TransactionFilters.getVisibilityFilter(tx, ttlByFamily, allowEmptyValues, type, filter);
+    return TransactionFilters.getVisibilityFilter(tx, ttlByFamily, allowEmptyValues, readNonTxnData, type, filter);
   }
 
   /**

--- a/tephra-hbase-compat-1.3/src/main/java/org/apache/tephra/hbase/coprocessor/TransactionVisibilityFilter.java
+++ b/tephra-hbase-compat-1.3/src/main/java/org/apache/tephra/hbase/coprocessor/TransactionVisibilityFilter.java
@@ -70,8 +70,8 @@ public class TransactionVisibilityFilter extends FilterBase {
    * @param scanType the type of scan operation being performed
    */
   public TransactionVisibilityFilter(Transaction tx, Map<byte[], Long> ttlByFamily, boolean allowEmptyValues,
-                              ScanType scanType) {
-    this(tx, ttlByFamily, allowEmptyValues, scanType, null);
+                                     ScanType scanType) {
+    this(tx, ttlByFamily, allowEmptyValues, false, scanType, null);
   }
 
   /**
@@ -81,19 +81,20 @@ public class TransactionVisibilityFilter extends FilterBase {
    * @param ttlByFamily map of time-to-live (TTL) (in milliseconds) by column family name
    * @param allowEmptyValues if {@code true} cells with empty {@code byte[]} values will be returned, if {@code false}
    *                         these will be interpreted as "delete" markers and the column will be filtered out
+   * @param readNonTxnData whether data written before Tephra was enabled on a table should be readable
    * @param scanType the type of scan operation being performed
    * @param cellFilter if non-null, this filter will be applied to all cells visible to the current transaction, by
    *                   calling {@link Filter#filterKeyValue(org.apache.hadoop.hbase.Cell)}.  If null, then
    *                   {@link Filter.ReturnCode#INCLUDE_AND_NEXT_COL} will be returned instead.
    */
-   public TransactionVisibilityFilter(Transaction tx, Map<byte[], Long> ttlByFamily, boolean allowEmptyValues,
-                               ScanType scanType, @Nullable Filter cellFilter) {
+  public TransactionVisibilityFilter(Transaction tx, Map<byte[], Long> ttlByFamily, boolean allowEmptyValues,
+                                     boolean readNonTxnData, ScanType scanType, @Nullable Filter cellFilter) {
     this.tx = tx;
     this.oldestTsByFamily = Maps.newTreeMap();
     for (Map.Entry<byte[], Long> ttlEntry : ttlByFamily.entrySet()) {
       long familyTTL = ttlEntry.getValue();
       oldestTsByFamily.put(new ImmutableBytesWritable(ttlEntry.getKey()),
-                           familyTTL <= 0 ? 0 : tx.getVisibilityUpperBound() - familyTTL * TxConstants.MAX_TX_PER_MS);
+                           TxUtils.getOldestVisibleTimestamp(familyTTL, tx, readNonTxnData));
     }
     this.allowEmptyValues = allowEmptyValues;
     this.clearDeletes =

--- a/tephra-hbase-compat-1.3/src/test/java/org/apache/tephra/hbase/coprocessor/TransactionVisibilityFilterTest.java
+++ b/tephra-hbase-compat-1.3/src/test/java/org/apache/tephra/hbase/coprocessor/TransactionVisibilityFilterTest.java
@@ -74,7 +74,7 @@ public class TransactionVisibilityFilterTest extends AbstractTransactionVisibili
     TxFilterFactory txFilterFactory = new TxFilterFactory() {
       @Override
       public Filter getTxFilter(Transaction tx, Map<byte[], Long> familyTTLs) {
-        return new TransactionVisibilityFilter(tx, familyTTLs, false, ScanType.USER_SCAN, includeFilter);
+        return new TransactionVisibilityFilter(tx, familyTTLs, false, false, ScanType.USER_SCAN, includeFilter);
       }
     };
     runFilteringTest(txFilterFactory,
@@ -94,7 +94,7 @@ public class TransactionVisibilityFilterTest extends AbstractTransactionVisibili
     txFilterFactory = new TxFilterFactory() {
       @Override
       public Filter getTxFilter(Transaction tx, Map<byte[], Long> familyTTLs) {
-        return new TransactionVisibilityFilter(tx, familyTTLs, false, ScanType.USER_SCAN, skipFilter);
+        return new TransactionVisibilityFilter(tx, familyTTLs, false, false, ScanType.USER_SCAN, skipFilter);
       }
     };
     runFilteringTest(txFilterFactory,
@@ -114,7 +114,7 @@ public class TransactionVisibilityFilterTest extends AbstractTransactionVisibili
     txFilterFactory = new TxFilterFactory() {
       @Override
       public Filter getTxFilter(Transaction tx, Map<byte[], Long> familyTTLs) {
-        return new TransactionVisibilityFilter(tx, familyTTLs, false, ScanType.USER_SCAN, includeNextFilter);
+        return new TransactionVisibilityFilter(tx, familyTTLs, false, false, ScanType.USER_SCAN, includeNextFilter);
       }
     };
     runFilteringTest(txFilterFactory,
@@ -134,7 +134,7 @@ public class TransactionVisibilityFilterTest extends AbstractTransactionVisibili
     txFilterFactory = new TxFilterFactory() {
       @Override
       public Filter getTxFilter(Transaction tx, Map<byte[], Long> familyTTLs) {
-        return new TransactionVisibilityFilter(tx, familyTTLs, false, ScanType.USER_SCAN, nextColFilter);
+        return new TransactionVisibilityFilter(tx, familyTTLs, false, false, ScanType.USER_SCAN, nextColFilter);
       }
     };
     runFilteringTest(txFilterFactory,
@@ -294,8 +294,9 @@ public class TransactionVisibilityFilterTest extends AbstractTransactionVisibili
     ttls.put(FAM2, 30L);
     ttls.put(FAM3, 0L);
 
-    Transaction tx = txManager.startShort();
-    long now = tx.getVisibilityUpperBound();
+    long now = System.currentTimeMillis() * TxConstants.MAX_TX_PER_MS;
+    // we explicitly set the readPointer to 'now', because if you set it to an older value, it can filter values out
+    Transaction tx = new Transaction(now, now, new long[0], new long[0], now);
     Filter filter = new TransactionVisibilityFilter(tx, ttls, false, ScanType.USER_SCAN);
     assertEquals(Filter.ReturnCode.INCLUDE_AND_NEXT_COL,
                  filter.filterKeyValue(newKeyValue("row1", FAM, "val1", now)));
@@ -353,7 +354,7 @@ public class TransactionVisibilityFilterTest extends AbstractTransactionVisibili
   private class CustomTxFilter extends TransactionVisibilityFilter {
     public CustomTxFilter(Transaction tx, Map<byte[], Long> ttlByFamily, boolean allowEmptyValues, ScanType scanType,
                           @Nullable Filter cellFilter) {
-      super(tx, ttlByFamily, allowEmptyValues, scanType, cellFilter);
+      super(tx, ttlByFamily, allowEmptyValues, false, scanType, cellFilter);
     }
 
     @Override


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TEPHRA-263
Instead of filtering data that is older than `tx.getVisibilityUpperBound - TTL`, we now filter data that is `tx.getTransactionId - TTL`.

This PR also makes two additional changes:
1. A large TTL (50 years, for instance) previously caused an exception since HBase start timestamps can not be negative.
2. TTL is now more accurately applied for TransactionVisibilityFilter, where `readNonTxnData` is true.

I'll apply the diff to the other hbase compat modules once these changes pass review.