### PR TITLE
TEPHRA-287 ActionChange.getChangeKey() not implemented correctly

### DIFF
--- a/tephra-core/src/main/java/org/apache/tephra/AbstractTransactionAwareTable.java
+++ b/tephra-core/src/main/java/org/apache/tephra/AbstractTransactionAwareTable.java
@@ -24,6 +24,8 @@ import com.google.common.collect.Sets;
 import com.google.common.primitives.Bytes;
 import com.google.common.primitives.UnsignedBytes;
 
+import org.apache.hadoop.io.WritableUtils;
+
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
@@ -42,15 +44,18 @@ public abstract class AbstractTransactionAwareTable implements TransactionAware 
   // map of write pointers to change set associated with each
   protected final Map<Long, Set<ActionChange>> changeSets;
   protected final TxConstants.ConflictDetection conflictLevel;
+  protected final boolean pre014ChangeSetKey;
   protected Transaction tx;
   protected boolean allowNonTransactional;
   protected static final byte[] SEPARATOR_BYTE_ARRAY = new byte[] {0};
 
-  public AbstractTransactionAwareTable(TxConstants.ConflictDetection conflictLevel, boolean allowNonTransactional) {
+  public AbstractTransactionAwareTable(TxConstants.ConflictDetection conflictLevel,
+      boolean allowNonTransactional, boolean pre014ChangeSetKey) {
     this.conflictLevel = conflictLevel;
     this.allowNonTransactional = allowNonTransactional;
     this.txCodec = new TransactionCodec();
     this.changeSets = Maps.newHashMap();
+    this.pre014ChangeSetKey = pre014ChangeSetKey;
   }
 
   /**
@@ -88,13 +93,97 @@ public abstract class AbstractTransactionAwareTable implements TransactionAware 
     Collection<byte[]> txChanges = new TreeSet<byte[]>(UnsignedBytes.lexicographicalComparator());
     for (Set<ActionChange> changeSet : changeSets.values()) {
       for (ActionChange change : changeSet) {
-        txChanges.add(getChangeKey(change.getRow(), change.getFamily(), change.getQualifier()));
+        byte[] row = change.getRow();
+        byte[] fam = change.getFamily();
+        byte[] qual = change.getQualifier();
+        txChanges.add(getChangeKey(row, fam, qual));
+        if (pre014ChangeSetKey) {
+          txChanges.add(getChangeKeyWithoutSeparators(row, fam, qual));
+        }
       }
     }
     return txChanges;
   }
 
+  /**
+   * @param vint long to make a vint of.
+   * @return long in vint byte array representation
+   * We could alternatively make this abstract and
+   * implement this method as Bytes.vintToBytes(long) in
+   * every compat module. 
+   */
+  protected byte [] getVIntBytes(final long vint) {
+    long i = vint;
+    int size = WritableUtils.getVIntSize(i);
+    byte [] result = new byte[size];
+    int offset = 0;
+    if (i >= -112 && i <= 127) {
+      result[offset] = (byte) i;
+      return result;
+    }
+
+    int len = -112;
+    if (i < 0) {
+      i ^= -1L; // take one's complement'
+      len = -120;
+    }
+
+    long tmp = i;
+    while (tmp != 0) {
+      tmp = tmp >> 8;
+    len--;
+    }
+
+    result[offset++] = (byte) len;
+
+    len = (len < -120) ? -(len + 120) : -(len + 112);
+
+    for (int idx = len; idx != 0; idx--) {
+      int shiftbits = (idx - 1) * 8;
+      long mask = 0xFFL << shiftbits;
+      result[offset++] = (byte) ((i & mask) >> shiftbits);
+    }
+    return result;
+  }
+
+  /**
+   * The unique bytes identifying what is changing. We use the
+   * following structure:
+   * ROW conflict level: <table_name><0 byte separator><row key>
+   * since we know that table_name cannot contain a zero byte.
+   * COLUMN conflict level: <table_name><length of family as vint><family>
+   *     <length of qualifier as vint><qualifier><row>
+   * The last part of the change key does not need the length to be part
+   * of the key since there's nothing after it that may overlap with it.
+   * @param row
+   * @param family
+   * @param qualifier 
+   * @return unique change key
+   */
   public byte[] getChangeKey(byte[] row, byte[] family, byte[] qualifier) {
+    return getChangeKeyWithSeparators(row, family, qualifier);
+  }
+  
+  private byte[] getChangeKeyWithSeparators(byte[] row, byte[] family, byte[] qualifier) {
+    byte[] key;
+    byte[] tableKey = getTableKey();
+    switch (conflictLevel) {
+    case ROW:
+      key = Bytes.concat(tableKey, SEPARATOR_BYTE_ARRAY, row);
+      break;
+    case COLUMN:
+      key = Bytes.concat(tableKey, SEPARATOR_BYTE_ARRAY, getVIntBytes(family.length), family,
+          getVIntBytes(qualifier.length), qualifier, row);
+      break;
+    case NONE:
+      throw new IllegalStateException("NONE conflict detection does not support change keys");
+    default:
+      throw new IllegalStateException("Unknown conflict detection level: " + conflictLevel);
+    }
+    return key;
+  }
+
+  private byte[] getChangeKeyWithoutSeparators(byte[] row, byte[] family, byte[] qualifier) {
     byte[] key;
     byte[] tableKey = getTableKey();
     switch (conflictLevel) {
@@ -102,7 +191,7 @@ public abstract class AbstractTransactionAwareTable implements TransactionAware 
       key = Bytes.concat(tableKey, row);
       break;
     case COLUMN:
-      key = Bytes.concat(tableKey, row, family, qualifier);
+      key = Bytes.concat(tableKey, family, qualifier, row);
       break;
     case NONE:
       throw new IllegalStateException("NONE conflict detection does not support change keys");

--- a/tephra-core/src/main/java/org/apache/tephra/TxConstants.java
+++ b/tephra-core/src/main/java/org/apache/tephra/TxConstants.java
@@ -124,6 +124,13 @@ public class TxConstants {
    */
   public static final String CLIENT_ID = "tephra.client.id";
 
+  /** Whether or not to put separators in change set row keys  (see TEPHRA-287).
+   * Currently defaults to true so that a mix of old and new tx clients will
+   * consistenly use the old logic. Once all clients are know to be upgraded
+   * the default should be change to false */
+  public static final String TX_PRE_014_CHANGESET_KEY = "data.tx.pre.014.changeset.key";
+  public static final boolean DEFAULT_TX_PRE_014_CHANGESET_KEY = true;
+
   /**
    * TransactionManager configuration.
    */
@@ -196,7 +203,7 @@ public class TxConstants {
     public static final long DEFAULT_TX_CHANGESET_SIZE_LIMIT = Long.MAX_VALUE;
     /** The default warning threshold for the total size in bytes of a change set is unlimited. */
     public static final long DEFAULT_TX_CHANGESET_SIZE_WARN_THRESHOLD = Long.MAX_VALUE;
-
+ 
     /** Whether and how long to retain the client id of a transaction. Valid values are:
      * <ul>
      *   <li>OFF - do not retain the client id at all</li>

--- a/tephra-hbase-compat-0.96/src/main/java/org/apache/tephra/hbase/TransactionAwareHTable.java
+++ b/tephra-hbase-compat-0.96/src/main/java/org/apache/tephra/hbase/TransactionAwareHTable.java
@@ -106,7 +106,10 @@ public class TransactionAwareHTable extends AbstractTransactionAwareTable
    */
   public TransactionAwareHTable(HTableInterface hTable, TxConstants.ConflictDetection conflictLevel,
                                 boolean allowNonTransactional) {
-    super(conflictLevel, allowNonTransactional);
+    super(conflictLevel, allowNonTransactional, 
+        hTable.getConfiguration().getBoolean(
+            TxConstants.TX_PRE_014_CHANGESET_KEY,
+            TxConstants.DEFAULT_TX_PRE_014_CHANGESET_KEY));
     this.hTable = hTable;
   }
 

--- a/tephra-hbase-compat-0.96/src/test/java/org/apache/tephra/hbase/TransactionAwareHTableTest.java
+++ b/tephra-hbase-compat-0.96/src/test/java/org/apache/tephra/hbase/TransactionAwareHTableTest.java
@@ -931,7 +931,10 @@ public class TransactionAwareHTableTest extends AbstractHBaseTableTest {
 
     Collection<byte[]> changeSet = txTable1.getTxChanges();
     assertNotNull(changeSet);
-    assertEquals(2, changeSet.size());
+    boolean pre014ChangeSetKeys = txTable1.getConfiguration().getBoolean(
+        TxConstants.TX_PRE_014_CHANGESET_KEY,
+        TxConstants.DEFAULT_TX_PRE_014_CHANGESET_KEY);
+    assertEquals(pre014ChangeSetKeys ? 4 : 2, changeSet.size());
     assertTrue(changeSet.contains(txTable1.getChangeKey(row1, null, null)));
     assertTrue(changeSet.contains(txTable1.getChangeKey(row2, null, null)));
     txContext1.finish();

--- a/tephra-hbase-compat-0.98/src/main/java/org/apache/tephra/hbase/TransactionAwareHTable.java
+++ b/tephra-hbase-compat-0.98/src/main/java/org/apache/tephra/hbase/TransactionAwareHTable.java
@@ -110,7 +110,10 @@ public class TransactionAwareHTable extends AbstractTransactionAwareTable
    */
   public TransactionAwareHTable(HTableInterface hTable, TxConstants.ConflictDetection conflictLevel,
                                 boolean allowNonTransactional) {
-    super(conflictLevel, allowNonTransactional);
+    super(conflictLevel, allowNonTransactional, 
+        hTable.getConfiguration().getBoolean(
+            TxConstants.TX_PRE_014_CHANGESET_KEY,
+            TxConstants.DEFAULT_TX_PRE_014_CHANGESET_KEY));
     this.hTable = hTable;
   }
 

--- a/tephra-hbase-compat-0.98/src/test/java/org/apache/tephra/hbase/TransactionAwareHTableTest.java
+++ b/tephra-hbase-compat-0.98/src/test/java/org/apache/tephra/hbase/TransactionAwareHTableTest.java
@@ -931,7 +931,10 @@ public class TransactionAwareHTableTest extends AbstractHBaseTableTest {
 
     Collection<byte[]> changeSet = txTable1.getTxChanges();
     assertNotNull(changeSet);
-    assertEquals(2, changeSet.size());
+    boolean pre014ChangeSetKeys = txTable1.getConfiguration().getBoolean(
+        TxConstants.TX_PRE_014_CHANGESET_KEY,
+        TxConstants.DEFAULT_TX_PRE_014_CHANGESET_KEY);
+    assertEquals(pre014ChangeSetKeys ? 4 : 2, changeSet.size());
     assertTrue(changeSet.contains(txTable1.getChangeKey(row1, null, null)));
     assertTrue(changeSet.contains(txTable1.getChangeKey(row2, null, null)));
     txContext1.finish();

--- a/tephra-hbase-compat-1.0-cdh/src/main/java/org/apache/tephra/hbase/TransactionAwareHTable.java
+++ b/tephra-hbase-compat-1.0-cdh/src/main/java/org/apache/tephra/hbase/TransactionAwareHTable.java
@@ -110,7 +110,10 @@ public class TransactionAwareHTable extends AbstractTransactionAwareTable
    */
   public TransactionAwareHTable(HTableInterface hTable, TxConstants.ConflictDetection conflictLevel,
                                 boolean allowNonTransactional) {
-    super(conflictLevel, allowNonTransactional);
+    super(conflictLevel, allowNonTransactional, 
+        hTable.getConfiguration().getBoolean(
+            TxConstants.TX_PRE_014_CHANGESET_KEY,
+            TxConstants.DEFAULT_TX_PRE_014_CHANGESET_KEY));
     this.hTable = hTable;
   }
 

--- a/tephra-hbase-compat-1.0-cdh/src/test/java/org/apache/tephra/hbase/TransactionAwareHTableTest.java
+++ b/tephra-hbase-compat-1.0-cdh/src/test/java/org/apache/tephra/hbase/TransactionAwareHTableTest.java
@@ -931,7 +931,10 @@ public class TransactionAwareHTableTest extends AbstractHBaseTableTest {
 
     Collection<byte[]> changeSet = txTable1.getTxChanges();
     assertNotNull(changeSet);
-    assertEquals(2, changeSet.size());
+    boolean pre014ChangeSetKeys = txTable1.getConfiguration().getBoolean(
+        TxConstants.TX_PRE_014_CHANGESET_KEY,
+        TxConstants.DEFAULT_TX_PRE_014_CHANGESET_KEY);
+    assertEquals(pre014ChangeSetKeys ? 4 : 2, changeSet.size());
     assertTrue(changeSet.contains(txTable1.getChangeKey(row1, null, null)));
     assertTrue(changeSet.contains(txTable1.getChangeKey(row2, null, null)));
     txContext1.finish();

--- a/tephra-hbase-compat-1.0/src/main/java/org/apache/tephra/hbase/TransactionAwareHTable.java
+++ b/tephra-hbase-compat-1.0/src/main/java/org/apache/tephra/hbase/TransactionAwareHTable.java
@@ -110,7 +110,10 @@ public class TransactionAwareHTable extends AbstractTransactionAwareTable
    */
   public TransactionAwareHTable(HTableInterface hTable, TxConstants.ConflictDetection conflictLevel,
                                 boolean allowNonTransactional) {
-    super(conflictLevel, allowNonTransactional);
+    super(conflictLevel, allowNonTransactional, 
+        hTable.getConfiguration().getBoolean(
+            TxConstants.TX_PRE_014_CHANGESET_KEY,
+            TxConstants.DEFAULT_TX_PRE_014_CHANGESET_KEY));
     this.hTable = hTable;
   }
 

--- a/tephra-hbase-compat-1.0/src/test/java/org/apache/tephra/hbase/TransactionAwareHTableTest.java
+++ b/tephra-hbase-compat-1.0/src/test/java/org/apache/tephra/hbase/TransactionAwareHTableTest.java
@@ -931,7 +931,10 @@ public class TransactionAwareHTableTest extends AbstractHBaseTableTest {
 
     Collection<byte[]> changeSet = txTable1.getTxChanges();
     assertNotNull(changeSet);
-    assertEquals(2, changeSet.size());
+    boolean pre014ChangeSetKeys = txTable1.getConfiguration().getBoolean(
+        TxConstants.TX_PRE_014_CHANGESET_KEY,
+        TxConstants.DEFAULT_TX_PRE_014_CHANGESET_KEY);
+    assertEquals(pre014ChangeSetKeys ? 4 : 2, changeSet.size());
     assertTrue(changeSet.contains(txTable1.getChangeKey(row1, null, null)));
     assertTrue(changeSet.contains(txTable1.getChangeKey(row2, null, null)));
     txContext1.finish();

--- a/tephra-hbase-compat-1.1-base/src/main/java/org/apache/tephra/hbase/TransactionAwareHTable.java
+++ b/tephra-hbase-compat-1.1-base/src/main/java/org/apache/tephra/hbase/TransactionAwareHTable.java
@@ -110,7 +110,10 @@ public class TransactionAwareHTable extends AbstractTransactionAwareTable
    */
   public TransactionAwareHTable(Table hTable, TxConstants.ConflictDetection conflictLevel,
                                 boolean allowNonTransactional) {
-    super(conflictLevel, allowNonTransactional);
+    super(conflictLevel, allowNonTransactional, 
+        hTable.getConfiguration().getBoolean(
+            TxConstants.TX_PRE_014_CHANGESET_KEY,
+            TxConstants.DEFAULT_TX_PRE_014_CHANGESET_KEY));
     this.hTable = hTable;
   }
 

--- a/tephra-hbase-compat-1.1-base/src/test/java/org/apache/tephra/hbase/TransactionAwareHTableTest.java
+++ b/tephra-hbase-compat-1.1-base/src/test/java/org/apache/tephra/hbase/TransactionAwareHTableTest.java
@@ -943,7 +943,10 @@ public class TransactionAwareHTableTest extends AbstractHBaseTableTest {
 
     Collection<byte[]> changeSet = txTable1.getTxChanges();
     assertNotNull(changeSet);
-    assertEquals(2, changeSet.size());
+    boolean pre014ChangeSetKeys = txTable1.getConfiguration().getBoolean(
+        TxConstants.TX_PRE_014_CHANGESET_KEY,
+        TxConstants.DEFAULT_TX_PRE_014_CHANGESET_KEY);
+    assertEquals(pre014ChangeSetKeys ? 4 : 2, changeSet.size());
     assertTrue(changeSet.contains(txTable1.getChangeKey(row1, null, null)));
     assertTrue(changeSet.contains(txTable1.getChangeKey(row2, null, null)));
     txContext1.finish();

--- a/tephra-hbase-compat-1.3/src/main/java/org/apache/tephra/hbase/TransactionAwareHTable.java
+++ b/tephra-hbase-compat-1.3/src/main/java/org/apache/tephra/hbase/TransactionAwareHTable.java
@@ -110,7 +110,10 @@ public class TransactionAwareHTable extends AbstractTransactionAwareTable
    */
   public TransactionAwareHTable(HTableInterface hTable, TxConstants.ConflictDetection conflictLevel,
                                 boolean allowNonTransactional) {
-    super(conflictLevel, allowNonTransactional);
+    super(conflictLevel, allowNonTransactional, 
+        hTable.getConfiguration().getBoolean(
+            TxConstants.TX_PRE_014_CHANGESET_KEY,
+            TxConstants.DEFAULT_TX_PRE_014_CHANGESET_KEY));
     this.hTable = hTable;
   }
 

--- a/tephra-hbase-compat-1.3/src/test/java/org/apache/tephra/hbase/TransactionAwareHTableTest.java
+++ b/tephra-hbase-compat-1.3/src/test/java/org/apache/tephra/hbase/TransactionAwareHTableTest.java
@@ -937,7 +937,10 @@ public class TransactionAwareHTableTest extends AbstractHBaseTableTest {
 
     Collection<byte[]> changeSet = txTable1.getTxChanges();
     assertNotNull(changeSet);
-    assertEquals(2, changeSet.size());
+    boolean pre014ChangeSetKeys = txTable1.getConfiguration().getBoolean(
+        TxConstants.TX_PRE_014_CHANGESET_KEY,
+        TxConstants.DEFAULT_TX_PRE_014_CHANGESET_KEY);
+    assertEquals(pre014ChangeSetKeys ? 4 : 2, changeSet.size());
     assertTrue(changeSet.contains(txTable1.getChangeKey(row1, null, null)));
     assertTrue(changeSet.contains(txTable1.getChangeKey(row2, null, null)));
     txContext1.finish();

--- a/tephra-hbase-compat-1.4/src/main/java/org/apache/tephra/hbase/TransactionAwareHTable.java
+++ b/tephra-hbase-compat-1.4/src/main/java/org/apache/tephra/hbase/TransactionAwareHTable.java
@@ -110,7 +110,10 @@ public class TransactionAwareHTable extends AbstractTransactionAwareTable
    */
   public TransactionAwareHTable(HTableInterface hTable, TxConstants.ConflictDetection conflictLevel,
                                 boolean allowNonTransactional) {
-    super(conflictLevel, allowNonTransactional);
+    super(conflictLevel, allowNonTransactional, 
+        hTable.getConfiguration().getBoolean(
+            TxConstants.TX_PRE_014_CHANGESET_KEY,
+            TxConstants.DEFAULT_TX_PRE_014_CHANGESET_KEY));
     this.hTable = hTable;
   }
 

--- a/tephra-hbase-compat-1.4/src/test/java/org/apache/tephra/hbase/TransactionAwareHTableTest.java
+++ b/tephra-hbase-compat-1.4/src/test/java/org/apache/tephra/hbase/TransactionAwareHTableTest.java
@@ -937,7 +937,10 @@ public class TransactionAwareHTableTest extends AbstractHBaseTableTest {
 
     Collection<byte[]> changeSet = txTable1.getTxChanges();
     assertNotNull(changeSet);
-    assertEquals(2, changeSet.size());
+    boolean pre014ChangeSetKeys = txTable1.getConfiguration().getBoolean(
+        TxConstants.TX_PRE_014_CHANGESET_KEY,
+        TxConstants.DEFAULT_TX_PRE_014_CHANGESET_KEY);
+    assertEquals(pre014ChangeSetKeys ? 4 : 2, changeSet.size());
     assertTrue(changeSet.contains(txTable1.getChangeKey(row1, null, null)));
     assertTrue(changeSet.contains(txTable1.getChangeKey(row2, null, null)));
     txContext1.finish();

--- a/tephra-hbase-compat-2.0/src/main/java/org/apache/tephra/hbase/TransactionAwareHTable.java
+++ b/tephra-hbase-compat-2.0/src/main/java/org/apache/tephra/hbase/TransactionAwareHTable.java
@@ -112,7 +112,10 @@ public class TransactionAwareHTable extends AbstractTransactionAwareTable
    */
   public TransactionAwareHTable(Table hTable, TxConstants.ConflictDetection conflictLevel,
       boolean allowNonTransactional) {
-    super(conflictLevel, allowNonTransactional);
+    super(conflictLevel, allowNonTransactional, 
+        hTable.getConfiguration().getBoolean(
+            TxConstants.TX_PRE_014_CHANGESET_KEY,
+            TxConstants.DEFAULT_TX_PRE_014_CHANGESET_KEY));
     this.hTable = hTable;
   }
 

--- a/tephra-hbase-compat-2.0/src/test/java/org/apache/tephra/hbase/TransactionAwareHTableTest.java
+++ b/tephra-hbase-compat-2.0/src/test/java/org/apache/tephra/hbase/TransactionAwareHTableTest.java
@@ -977,7 +977,10 @@ public class TransactionAwareHTableTest extends AbstractHBaseTableTest {
 
     Collection<byte[]> changeSet = txTable1.getTxChanges();
     assertNotNull(changeSet);
-    assertEquals(2, changeSet.size());
+    boolean pre014ChangeSetKeys = txTable1.getConfiguration().getBoolean(
+        TxConstants.TX_PRE_014_CHANGESET_KEY,
+        TxConstants.DEFAULT_TX_PRE_014_CHANGESET_KEY);
+    assertEquals(pre014ChangeSetKeys ? 4 : 2, changeSet.size());
     assertTrue(changeSet.contains(txTable1.getChangeKey(row1, null, null)));
     assertTrue(changeSet.contains(txTable1.getChangeKey(row2, null, null)));
     txContext1.finish();


### PR DESCRIPTION
Based on a new config parameter (defaulting to true), send the old change set row key and the new change set row key. This allows a mix of old and new clients to still detect conflicts across them. Once it's know that only new clients are being used, the config parameter can be switched to false in which case only the new change set row key (which correctly embeds separator bytes to prevent false positives) will be sent.